### PR TITLE
configurable health check

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -79,6 +79,18 @@ func (m *Manifest) Validate(env types.Environment) error {
 
 func (m *Manifest) applyDefaults() error {
 	for i, s := range m.Services {
+		if s.Health.Path == "" {
+			m.Services[i].Health.Path = "/"
+		}
+
+		if s.Health.Interval == 0 {
+			m.Services[i].Health.Interval = 5
+		}
+
+		if s.Health.Timeout == 0 {
+			m.Services[i].Health.Timeout = m.Services[i].Health.Interval - 1
+		}
+
 		if s.Scale.Count.Min == 0 {
 			m.Services[i].Scale.Count.Min = 1
 		}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -70,6 +70,11 @@ func TestManifestLoad(t *testing.T) {
 					"DEVELOPMENT=false",
 					"SECRET",
 				},
+				Health: manifest.ServiceHealth{
+					Path:     "/",
+					Interval: 10,
+					Timeout:  9,
+				},
 				Resources: []string{"database"},
 				Scale: manifest.ServiceScale{
 					Count:  manifest.ServiceCount{Min: 3, Max: 10},
@@ -81,6 +86,11 @@ func TestManifestLoad(t *testing.T) {
 				Command: manifest.ServiceCommand{
 					Development: "bash",
 					Production:  "bash",
+				},
+				Health: manifest.ServiceHealth{
+					Path:     "/auth",
+					Interval: 5,
+					Timeout:  4,
 				},
 				Image: "ubuntu:16.04",
 				Environment: []string{

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -14,6 +14,7 @@ type Service struct {
 	Build       ServiceBuild
 	Command     ServiceCommand
 	Environment []string
+	Health      ServiceHealth
 	Image       string
 	Port        ServicePort
 	Resources   []string
@@ -37,6 +38,12 @@ type ServiceCommand struct {
 type ServiceCount struct {
 	Min int
 	Max int
+}
+
+type ServiceHealth struct {
+	Interval int
+	Path     string
+	Timeout  int
 }
 
 type ServicePort struct {

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -24,6 +24,8 @@ services:
     environment:
       - DEVELOPMENT=false
       - SECRET
+    health:
+      interval: 10
     resources:
       - database
     scale:
@@ -33,6 +35,7 @@ services:
     image: ubuntu:16.04
     environment:
       - SECRET
+    health: /auth
     scale:
       memory: 512
 tables:

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -168,13 +168,6 @@ func (v *ServiceCommand) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		if c, ok := t["production"].(string); ok {
 			v.Production = c
 		}
-		// type serviceBuild ServiceBuild
-		// var r serviceBuild
-		// if err := remarshal(w, &r); err != nil {
-		//   return err
-		// }
-		// v.Args = r.Args
-		// v.Path = r.Path
 	case string:
 		v.Development = t
 		v.Production = t
@@ -229,6 +222,33 @@ func (v *ServiceCount) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	default:
 		return fmt.Errorf("invalid scale: %v", w)
+	}
+
+	return nil
+}
+
+func (v *ServiceHealth) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var w interface{}
+
+	if err := unmarshal(&w); err != nil {
+		return err
+	}
+
+	switch t := w.(type) {
+	case map[interface{}]interface{}:
+		if w, ok := t["path"].(string); ok {
+			v.Path = w
+		}
+		if w, ok := t["interval"].(int); ok {
+			v.Interval = w
+		}
+		if w, ok := t["timeout"].(int); ok {
+			v.Timeout = w
+		}
+	case string:
+		v.Path = t
+	default:
+		return fmt.Errorf("unknown type for service health: %T", t)
 	}
 
 	return nil

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -152,10 +152,10 @@
       "Service{{ resource .Name }}TargetGroup": {
         "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
         "Properties": {
-          "HealthCheckIntervalSeconds": 10,
-          "HealthCheckTimeoutSeconds": 5,
+          "HealthCheckIntervalSeconds": {{ .Health.Interval }},
+          "HealthCheckTimeoutSeconds": {{ .Health.Timeout }},
           "UnhealthyThresholdCount": 2,
-          "HealthCheckPath": "/",
+          "HealthCheckPath": "{{ .Health.Path }}",
           "Port": "{{ .Port.Port }}",
           "Protocol": "{{ upper .Port.Scheme }}",
           "TargetGroupAttributes": [


### PR DESCRIPTION
```
services:
  web:
    health: /test
```

or

```
services:
  web:
    health:
      path: /foo
      interval: 5
      timeout: 3
```