### PR TITLE
automatic cdn support

### DIFF
--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -60,6 +60,7 @@ func TestManifestLoad(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Path: "api",
 				},
+				CDN: "foo.example.org",
 				Command: manifest.ServiceCommand{
 					Development: "rerun github.com/convox/praxis",
 					Test:        "make test",

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -12,6 +12,7 @@ type Service struct {
 	Name string
 
 	Build       ServiceBuild
+	CDN         string
 	Command     ServiceCommand
 	Environment []string
 	Health      ServiceHealth

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -18,6 +18,7 @@ services:
   api:
     build:
       path: api
+    cdn: foo.example.org
     command:
       development: rerun github.com/convox/praxis
       test: make test

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -1,6 +1,15 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Outputs": {
+    {{ range .Manifest.Services }}
+      "Endpoint{{ resource .Name }}": {
+        "Value": {{ if .CDN }}
+          { "Fn::GetAtt": [ "Service{{ resource .Name }}Cdn", "DomainName" ] }
+        {{ else }}
+          { "Fn::Sub": "{{ lower $.App.Name }}-{{ lower .Name }}.${Domain}" }
+        {{ end }}
+      },
+    {{ end }}
     "Release": {
       "Value": "{{ .Release.Id }}"
     }
@@ -26,6 +35,7 @@
   },
   "Resources": {
     {{ template "balancers" . }}
+    {{ template "cdns" . }}
     {{ template "keys" . }}
     {{ template "queues" . }}
     {{ template "resources" . }}
@@ -58,6 +68,55 @@
 }
 
 {{ define "balancers" }}
+{{ end }}
+
+{{ define "cdns" }}
+  {{ range $s := .Manifest.Services }}
+    {{ with .CDN }}
+      "Service{{ resource $s.Name }}Certificate": {
+        "Type": "AWS::CertificateManager::Certificate",
+        "Properties": {
+          "DomainName": "{{ . }}"
+        }
+      },
+      "Service{{ resource $s.Name }}Cdn": {
+        "Type": "AWS::CloudFront::Distribution",
+        "Properties": {
+          "DistributionConfig": {
+            "Comment": { "Fn::Sub": "${AWS::StackName} {{ $s.Name }} cdn" },
+            "DefaultCacheBehavior": {
+              "AllowedMethods": ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"],
+              "Compress": "true",
+              "ForwardedValues": {
+                "Cookies": { "Forward": "all" },
+                "Headers": [ "*" ],
+                "QueryString": "true"
+              },
+              "TargetOriginId": "default",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            "Enabled": "true",
+            "Origins": [
+              {
+                "CustomOriginConfig": {
+                  "HTTPSPort": "443",
+                  "OriginProtocolPolicy": "https-only",
+                  "OriginSSLProtocols": [ "TLSv1", "TLSv1.1", "TLSv1.2" ]
+                },
+                "DomainName": { "Fn::Sub": "{{ lower $.App.Name }}-{{ lower $s.Name }}.${Domain}" },
+                "Id": "default"
+              }
+            ],
+            "PriceClass": "PriceClass_100",
+            "ViewerCertificate": {
+              "AcmCertificateArn": { "Ref": "Service{{ resource $s.Name }}Certificate" },
+              "SslSupportMethod": "sni-only"
+            }
+          }
+        }
+      },
+    {{ end }}
+  {{ end }}
 {{ end }}
 
 {{ define "keys" }}
@@ -149,6 +208,26 @@
           "Priority": "{{ priority $.App.Name .Name }}"
         }
       },
+      {{ if .CDN }}
+        "Service{{ resource .Name }}ListenerRuleCdnRaw": {
+          "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+          "Properties": {
+            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Service{{ resource .Name }}TargetGroup" } } ],
+            "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::GetAtt": [ "Service{{ resource .Name }}Cdn", "DomainName" ] } ] } ],
+            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:BalancerListener" } },
+            "Priority": "{{ priority $.App.Name (print .CDN "Raw") }}"
+          }
+        },
+        "Service{{ resource .Name }}ListenerRuleCdnDomain": {
+          "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+          "Properties": {
+            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Service{{ resource .Name }}TargetGroup" } } ],
+            "Conditions": [ { "Field": "host-header", "Values": [ "{{ .CDN }}" ] } ],
+            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:BalancerListener" } },
+            "Priority": "{{ priority $.App.Name (print .CDN "Domain") }}"
+          }
+        },
+      {{ end }}
       "Service{{ resource .Name }}TargetGroup": {
         "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
         "Properties": {

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -81,7 +81,9 @@ func (p *Provider) ReleaseCreate(app string, opts types.ReleaseCreateOptions) (*
 		return nil, err
 	}
 
-	// fmt.Printf("string(data) = %+v\n", string(data))
+	fmt.Printf("string(data) = %+v\n", string(data))
+
+	// return nil, fmt.Errorf("stop")
 
 	domain, err := p.rackOutput("Domain")
 	if err != nil {

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -8,11 +8,6 @@ import (
 )
 
 func (p *Provider) ServiceList(app string) (types.Services, error) {
-	domain, err := p.rackOutput("Domain")
-	if err != nil {
-		return nil, err
-	}
-
 	a, err := p.AppGet(app)
 	if err != nil {
 		return nil, err
@@ -40,10 +35,9 @@ func (p *Provider) ServiceList(app string) (types.Services, error) {
 	ss := types.Services{}
 
 	for _, s := range m.Services {
-		endpoint := ""
-
-		if s.Port.Port > 0 {
-			endpoint = fmt.Sprintf("https://%s-%s.%s", app, s.Name, domain)
+		endpoint, err := p.appOutput(app, fmt.Sprintf("Endpoint%s", upperName(s.Name)))
+		if err != nil {
+			return nil, err
 		}
 
 		ss = append(ss, types.Service{


### PR DESCRIPTION
Add `cdn: domain.name` to a `services:` entry to get a CDN frontend with a certificate on a custom domain that redirects HTTP to HTTPS.