### PR TITLE
release goes to promoted status

### DIFF
--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -119,7 +119,7 @@ func (p *Provider) ReleaseLogs(app, id string, opts types.LogsOptions) (io.ReadC
 		}
 
 		switch r.Status {
-		case "complete", "failed":
+		case "complete", "failed", "promoted":
 			return false
 		}
 


### PR DESCRIPTION
I think the 'promoted' state should signal to stop following logs.

```
$ cx releases --app ui-staging
ID          BUILD       STATUS     CREATED
RCIWCSFBOU  BBWRNFYDWF  promoted   8 minutes ago
...
```