### PR TITLE
simplify cdn

### DIFF
--- a/cmd/cx/apps.go
+++ b/cmd/cx/apps.go
@@ -26,8 +26,8 @@ func init() {
 			},
 			cli.Command{
 				Name:        "info",
-				Description: "get info about an application",
-				Usage:       "<name>",
+				Description: "get application info",
+				Usage:       "[name]",
 				Action:      runAppsInfo,
 				Flags:       []cli.Flag{appFlag},
 			},

--- a/cmd/cx/info.go
+++ b/cmd/cx/info.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/convox/praxis/stdcli"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+func init() {
+	stdcli.RegisterCommand(cli.Command{
+		Name:        "info",
+		Description: "get application info",
+		Action:      runAppsInfo,
+		Flags:       []cli.Flag{appFlag},
+	})
+}

--- a/cmd/cx/rack.go
+++ b/cmd/cx/rack.go
@@ -48,7 +48,7 @@ func init() {
 				Name:        "install",
 				Description: "install a rack",
 				Action:      runRackInstall,
-				Usage:       "<provider> <name>",
+				Usage:       "<provider>",
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "name",
@@ -100,7 +100,7 @@ func init() {
 				Name:        "uninstall",
 				Description: "uninstall a rack",
 				Action:      runRackUninstall,
-				Usage:       "<provider> <name>",
+				Usage:       "<provider>",
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "name",

--- a/cmd/cx/releases.go
+++ b/cmd/cx/releases.go
@@ -178,7 +178,7 @@ func releaseLogs(app string, id string, w io.Writer) error {
 		return err
 	}
 
-	if err := helpers.HalfPipe(w, logs); err != nil {
+	if _, err := io.Copy(w, logs); err != nil {
 		return err
 	}
 

--- a/cmd/rack/main.go
+++ b/cmd/rack/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
+	"strings"
 
 	"github.com/convox/praxis/server"
 )
@@ -14,6 +16,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 		os.Exit(1)
 	}
+
+	go http.ListenAndServe(":3001", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := r.URL
+
+		u.Host = strings.Split(r.Host, ":")[0]
+		u.Scheme = "https"
+
+		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
+	}))
 
 	if err := s.Listen("tcp", ":3000"); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -99,7 +99,9 @@ func (m *Manifest) Build(root, prefix string, tag string, opts BuildOptions) err
 			return err
 		}
 
-		if err := opts.docker("push", to); err != nil {
+		fmt.Fprintf(opts.Stdout, "pushing: %s\n", to)
+
+		if err := opts.dockerq("push", to); err != nil {
 			return err
 		}
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -58,7 +58,7 @@ func TestManifestLoad(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Path: "api",
 				},
-				CDN: "foo.example.org",
+				Certificate: "foo.example.org",
 				Command: manifest.ServiceCommand{
 					Development: "rerun bar github.com/convox/praxis",
 					Test:        "make  test",

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -9,7 +9,7 @@ type Service struct {
 	Name string
 
 	Build       ServiceBuild
-	CDN         string
+	Certificate string
 	Command     ServiceCommand
 	Environment []string
 	Health      ServiceHealth

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -18,7 +18,7 @@ services:
   api:
     build:
       path: api
-    cdn: foo.example.org
+    certificate: foo.example.org
     command:
       development: rerun ${FOO} github.com/convox/praxis
       test: make ${BAR} test

--- a/provider/aws/app.go
+++ b/provider/aws/app.go
@@ -44,17 +44,19 @@ func (p *Provider) AppCreate(name string) (*types.App, error) {
 }
 
 func (p *Provider) AppDelete(name string) error {
-	if bucket, err := p.appResource(name, "Bucket"); err == nil && bucket != "" {
-		if err := p.deleteBucket(bucket); err != nil {
-			fmt.Println("ns=provider.aws at=app.delete error=%q\n", err)
-		}
-	}
+	bucket, _ := p.appResource(name, "Bucket")
 
 	_, err := p.CloudFormation().DeleteStack(&cloudformation.DeleteStackInput{
 		StackName: aws.String(fmt.Sprintf("%s-%s", p.Name, name)),
 	})
 	if err != nil {
 		return err
+	}
+
+	if bucket != "" {
+		if err := p.deleteBucket(bucket); err != nil {
+			fmt.Println("ns=provider.aws at=app.delete error=%q\n", err)
+		}
 	}
 
 	return nil

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -3,8 +3,8 @@
   "Outputs": {
     {{ range .Manifest.Services }}
       "Endpoint{{ resource .Name }}": {
-        "Value": {{ if .CDN }}
-          { "Fn::GetAtt": [ "Service{{ resource .Name }}Cdn", "DomainName" ] }
+        "Value": {{ if .Certificate }}
+          { "Fn::GetAtt": [ "Service{{ resource .Name }}Balancer", "DNSName" ] }
         {{ else }}
           { "Fn::Sub": "{{ lower $.App.Name }}-{{ lower .Name }}.${Domain}" }
         {{ end }}
@@ -35,7 +35,6 @@
   },
   "Resources": {
     {{ template "balancers" . }}
-    {{ template "cdns" . }}
     {{ template "keys" . }}
     {{ template "queues" . }}
     {{ template "resources" . }}
@@ -68,52 +67,70 @@
 }
 
 {{ define "balancers" }}
-{{ end }}
-
-{{ define "cdns" }}
   {{ range $s := .Manifest.Services }}
-    {{ with .CDN }}
+    {{ with .Certificate }}
       "Service{{ resource $s.Name }}Certificate": {
         "Type": "AWS::CertificateManager::Certificate",
         "Properties": {
           "DomainName": "{{ . }}"
         }
       },
-      "Service{{ resource $s.Name }}Cdn": {
-        "Type": "AWS::CloudFront::Distribution",
+      "Service{{ resource $s.Name }}Balancer": {
+        "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
         "Properties": {
-          "DistributionConfig": {
-            "Aliases": [ "{{ . }}" ],
-            "Comment": { "Fn::Sub": "${AWS::StackName} {{ $s.Name }} cdn" },
-            "DefaultCacheBehavior": {
-              "AllowedMethods": ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"],
-              "Compress": "true",
-              "ForwardedValues": {
-                "Cookies": { "Forward": "all" },
-                "Headers": [ "*" ],
-                "QueryString": "true"
-              },
-              "TargetOriginId": "default",
-              "ViewerProtocolPolicy": "redirect-to-https"
-            },
-            "Enabled": "true",
-            "Origins": [
-              {
-                "CustomOriginConfig": {
-                  "HTTPSPort": "443",
-                  "OriginProtocolPolicy": "https-only",
-                  "OriginSSLProtocols": [ "TLSv1", "TLSv1.1", "TLSv1.2" ]
-                },
-                "DomainName": { "Fn::Sub": "{{ lower $.App.Name }}-{{ lower $s.Name }}.${Domain}" },
-                "Id": "default"
-              }
-            ],
-            "PriceClass": "PriceClass_100",
-            "ViewerCertificate": {
-              "AcmCertificateArn": { "Ref": "Service{{ resource $s.Name }}Certificate" },
-              "SslSupportMethod": "sni-only"
-            }
-          }
+          "Scheme": "internet-facing",
+          "SecurityGroups": [ { "Ref": "Service{{ resource $s.Name }}BalancerSecurity" } ],
+          "Subnets": [
+            { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet0" } },
+            { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Subnet1" } }
+          ]
+        }
+      },
+      "Service{{ resource $s.Name }}BalancerListener80": {
+        "Type": "AWS::ElasticLoadBalancingV2::Listener",
+        "Properties": {
+        "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Service{{ resource $s.Name }}BalancerTargetGroup" } } ],
+          "LoadBalancerArn": { "Ref" : "Service{{ resource $s.Name }}Balancer" },
+          "Port": "80",
+          "Protocol": "HTTP"
+        }
+      },
+      "Service{{ resource $s.Name }}BalancerListener443": {
+        "Type": "AWS::ElasticLoadBalancingV2::Listener",
+        "Properties": {
+          "Certificates": [ { "CertificateArn": { "Ref": "Service{{ resource $s.Name }}Certificate" } } ],
+          "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Service{{ resource $s.Name }}BalancerTargetGroup" } } ],
+          "LoadBalancerArn": { "Ref" : "Service{{ resource $s.Name }}Balancer" },
+          "Port": "443",
+          "Protocol": "HTTPS"
+        }
+      },
+      "Service{{ resource $s.Name }}BalancerSecurity": {
+        "Type": "AWS::EC2::SecurityGroup",
+        "Properties": {
+          "GroupDescription": { "Fn::Sub": "${AWS::StackName} balancer" },
+          "SecurityGroupIngress": [
+            { "IpProtocol": "tcp", "FromPort": "80", "ToPort": "80", "CidrIp": "0.0.0.0/0" },
+            { "IpProtocol": "tcp", "FromPort": "443", "ToPort": "443", "CidrIp": "0.0.0.0/0" }
+          ],
+          "Tags": [ { "Key": "Name", "Value": { "Fn::Sub": "${AWS::StackName}-balancer" } } ],
+          "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
+        }
+      },
+      "Service{{ resource $s.Name }}BalancerTargetGroup": {
+        "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+        "Properties": {
+          "HealthCheckIntervalSeconds": {{ $s.Health.Interval }},
+          "HealthCheckTimeoutSeconds": {{ $s.Health.Timeout }},
+          "UnhealthyThresholdCount": 2,
+          "HealthCheckPath": "{{ $s.Health.Path }}",
+          "Port": "{{ $s.Port.Port }}",
+          "Protocol": "{{ upper $s.Port.Scheme }}",
+          "TargetGroupAttributes": [
+            { "Key": "deregistration_delay.timeout_seconds", "Value": "5" },
+            { "Key": "stickiness.enabled", "Value": "true" }
+          ],
+          "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
         }
       },
     {{ end }}
@@ -192,7 +209,11 @@
           "LoadBalancers": [ {
             "ContainerName": "{{ .Name }}",
             "ContainerPort": "{{ .Port.Port }}",
-            "TargetGroupArn": { "Ref": "Service{{ resource .Name }}TargetGroup" }
+            "TargetGroupArn": {{ if .Certificate }}
+              { "Ref": "Service{{ resource .Name }}BalancerTargetGroup" }
+            {{ else }}
+              { "Ref": "Service{{ resource .Name }}TargetGroup" }
+            {{ end }}
           } ],
           "Role": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:ServiceRole" } },
         {{ end }}
@@ -200,56 +221,42 @@
       }
     },
     {{ if .Port.Port }}
-      "Service{{ resource .Name }}ListenerRule": {
-        "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
-        "Properties": {
-          "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Service{{ resource .Name }}TargetGroup" } } ],
-          "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::Sub": "{{ lower $.App.Name }}-{{ lower .Name }}.${Domain}" } ] } ],
-          "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:BalancerListener" } },
-          "Priority": "{{ priority $.App.Name .Name }}"
-        }
-      },
-      {{ if .CDN }}
-        "Service{{ resource .Name }}ListenerRuleCdnRaw": {
+      {{ if not .Certificate }}
+        "Service{{ resource .Name }}ListenerRule": {
           "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
           "Properties": {
             "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Service{{ resource .Name }}TargetGroup" } } ],
-            "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::GetAtt": [ "Service{{ resource .Name }}Cdn", "DomainName" ] } ] } ],
+            "Conditions": [ { "Field": "host-header", "Values": [ { "Fn::Sub": "{{ lower $.App.Name }}-{{ lower .Name }}.${Domain}" } ] } ],
             "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:BalancerListener" } },
-            "Priority": "{{ priority $.App.Name (print .CDN "Raw") }}"
+            "Priority": "{{ priority $.App.Name .Name }}"
           }
         },
-        "Service{{ resource .Name }}ListenerRuleCdnDomain": {
-          "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+        "Service{{ resource .Name }}TargetGroup": {
+          "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
           "Properties": {
-            "Actions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "Service{{ resource .Name }}TargetGroup" } } ],
-            "Conditions": [ { "Field": "host-header", "Values": [ "{{ .CDN }}" ] } ],
-            "ListenerArn": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:BalancerListener" } },
-            "Priority": "{{ priority $.App.Name (print .CDN "Domain") }}"
+            "HealthCheckIntervalSeconds": {{ .Health.Interval }},
+            "HealthCheckTimeoutSeconds": {{ .Health.Timeout }},
+            "UnhealthyThresholdCount": 2,
+            "HealthCheckPath": "{{ .Health.Path }}",
+            "Port": "{{ .Port.Port }}",
+            "Protocol": "{{ upper .Port.Scheme }}",
+            "TargetGroupAttributes": [
+              { "Key": "deregistration_delay.timeout_seconds", "Value": "5" },
+              { "Key": "stickiness.enabled", "Value": "true" }
+            ],
+            "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
           }
         },
       {{ end }}
-      "Service{{ resource .Name }}TargetGroup": {
-        "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-        "Properties": {
-          "HealthCheckIntervalSeconds": {{ .Health.Interval }},
-          "HealthCheckTimeoutSeconds": {{ .Health.Timeout }},
-          "UnhealthyThresholdCount": 2,
-          "HealthCheckPath": "{{ .Health.Path }}",
-          "Port": "{{ .Port.Port }}",
-          "Protocol": "{{ upper .Port.Scheme }}",
-          "TargetGroupAttributes": [
-            { "Key": "deregistration_delay.timeout_seconds", "Value": "5" },
-            { "Key": "stickiness.enabled", "Value": "true" }
-          ],
-          "VpcId": { "Fn::ImportValue": { "Fn::Sub": "${Rack}:Vpc" } }
-        }
-      },
     {{ end }}
     "Service{{ resource .Name }}Tasks": {
       "Type": "AWS::ECS::TaskDefinition",
       {{ if .Port.Port }}
-        "DependsOn": "Service{{ resource .Name }}ListenerRule",
+        {{ if .Certificate }}
+          "DependsOn": [ "Service{{ resource .Name }}BalancerListener80", "Service{{ resource .Name }}BalancerListener443" ],
+        {{ else }}
+          "DependsOn": "Service{{ resource .Name }}ListenerRule",
+        {{ end }}
       {{ end }}
       "Properties": {
         "ContainerDefinitions": [ {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -293,6 +293,30 @@
         "Protocol": "HTTPS"
       }
     },
+    "BalancerRedirectListener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "BalancerRedirectTargetGroup" } } ],
+        "LoadBalancerArn": { "Ref" : "Balancer" },
+        "Port": "80",
+        "Protocol": "HTTP"
+      }
+    },
+    "BalancerRedirectTargetGroup": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "HealthCheckIntervalSeconds": 60,
+        "UnhealthyThresholdCount": 10,
+        "HealthCheckPath": "/",
+        "Port": "3001",
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": [
+          { "Key": "deregistration_delay.timeout_seconds", "Value": "2" },
+          { "Key": "stickiness.enabled", "Value": "true" }
+        ],
+        "VpcId": { "Fn::GetAtt": [ "Network", "Outputs.Vpc" ] }
+      }
+    },
     "BalancerSecurity": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -293,30 +293,6 @@
         "Protocol": "HTTPS"
       }
     },
-    "BalancerRedirectListener": {
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
-      "Properties": {
-        "DefaultActions": [ { "Type": "forward", "TargetGroupArn": { "Ref": "BalancerRedirectTargetGroup" } } ],
-        "LoadBalancerArn": { "Ref" : "Balancer" },
-        "Port": "80",
-        "Protocol": "HTTP"
-      }
-    },
-    "BalancerRedirectTargetGroup": {
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "Properties": {
-        "HealthCheckIntervalSeconds": 60,
-        "UnhealthyThresholdCount": 10,
-        "HealthCheckPath": "/",
-        "Port": "3001",
-        "Protocol": "HTTP",
-        "TargetGroupAttributes": [
-          { "Key": "deregistration_delay.timeout_seconds", "Value": "2" },
-          { "Key": "stickiness.enabled", "Value": "true" }
-        ],
-        "VpcId": { "Fn::GetAtt": [ "Network", "Outputs.Vpc" ] }
-      }
-    },
     "BalancerSecurity": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -236,7 +236,7 @@ func (p *Provider) ReleasePromote(app string, id string) error {
 
 	_, err = p.CloudFormation().UpdateStack(&cloudformation.UpdateStackInput{
 		Capabilities:       []*string{aws.String("CAPABILITY_IAM")},
-		ClientRequestToken: aws.String(r.Id),
+		ClientRequestToken: aws.String(fmt.Sprintf("%s-%s", r.Id, rs)),
 		Parameters:         params,
 		NotificationARNs:   []*string{aws.String(topic)},
 		StackName:          aws.String(stack),

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -144,12 +144,12 @@ func (p *Provider) ReleasePromote(app string, id string) error {
 		return fmt.Errorf("no build for release: %s", r.Id)
 	}
 
-	group, err := p.appResource(app, "Logs")
-	if err != nil {
-		return err
-	}
+	// group, err := p.appResource(app, "Logs")
+	// if err != nil {
+	//   return err
+	// }
 
-	stream := fmt.Sprintf("convox/release/%s", r.Id)
+	// stream := fmt.Sprintf("convox/release/%s", r.Id)
 
 	topic, err := p.rackResource("NotificationTopic")
 	if err != nil {
@@ -227,7 +227,12 @@ func (p *Provider) ReleasePromote(app string, id string) error {
 	//   return nil, err
 	// }
 
-	p.writeLogf(group, stream, "updating: %s", stack)
+	// p.writeLogf(group, stream, "updating: %s", stack)
+
+	rs, err := types.Key(4)
+	if err != nil {
+		return err
+	}
 
 	_, err = p.CloudFormation().UpdateStack(&cloudformation.UpdateStackInput{
 		Capabilities:       []*string{aws.String("CAPABILITY_IAM")},

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -119,7 +119,7 @@ func (p *Provider) ReleaseLogs(app, id string, opts types.LogsOptions) (io.ReadC
 		}
 
 		switch r.Status {
-		case "complete", "failed":
+		case "promoted", "failed":
 			return false
 		}
 

--- a/provider/aws/workers.go
+++ b/provider/aws/workers.go
@@ -250,6 +250,9 @@ func (p *Provider) handleNotifications(body string) error {
 		case "UPDATE_COMPLETE":
 			p.writeLogf(group, stream, "release promoted: %s", release)
 			r.Status = "promoted"
+		case "UPDATE_ROLLBACK_COMPLETE":
+			p.writeLogf(group, stream, "promote failed: %s", release)
+			r.Status = "failed"
 		}
 
 		if err := p.releaseStore(r); err != nil {

--- a/provider/aws/workers.go
+++ b/provider/aws/workers.go
@@ -228,14 +228,18 @@ func (p *Provider) handleNotifications(body string) error {
 		return err
 	}
 
-	stream := fmt.Sprintf("convox/release/%s", msg["ClientRequestToken"])
+	token := msg["ClientRequestToken"]
+	tp := strings.Split(token, "-")
+	release := tp[0]
+
+	stream := fmt.Sprintf("convox/release/%s", release)
 
 	app := strings.TrimPrefix(msg["StackName"], fmt.Sprintf("%s-", p.Name))
 
 	p.writeLogf(group, stream, "%-20s  %-28s  %s", msg["ResourceStatus"], msg["LogicalResourceId"], msg["ResourceType"])
 
 	if msg["LogicalResourceId"] == msg["StackName"] {
-		r, err := p.ReleaseGet(app, msg["ClientRequestToken"])
+		r, err := p.ReleaseGet(app, release)
 		if err != nil {
 			return err
 		}
@@ -244,7 +248,7 @@ func (p *Provider) handleNotifications(body string) error {
 		case "UPDATE_IN_PROGRESS":
 			r.Status = "promoting"
 		case "UPDATE_COMPLETE":
-			p.writeLogf(group, stream, "release promoted: %s", msg["ClientRequestToken"])
+			p.writeLogf(group, stream, "release promoted: %s", release)
 			r.Status = "promoted"
 		}
 


### PR DESCRIPTION
* `cdn: some.domain.org` now becomes `certificate: some.domain.org` and is implemented as a second ALB.. much faster and without CloudFront baggage around websockets.. this balancer listens on both 80 and 443
* main rack load balancer gets a listener on 80 that redirects everything to https as a 307
