### PR TITLE
staged builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
+## convox:development
+
 FROM convox/golang
 
+ENV DEVELOPMENT=true
+
 WORKDIR $GOPATH/src/github.com/convox/praxis
+
 COPY . .
+
+CMD ["rerun", "-watch", ".", "-build", "github.com/convox/praxis/cmd/rack"]
+
+## convox:production
+
+ENV DEVELOPMENT=false
+
+WORKDIR $GOPATH/src/github.com/convox/praxis
+
 RUN go install ./cmd/...
 
 CMD ["rack"]

--- a/bin/ecs-amis
+++ b/bin/ecs-amis
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+die() {
+  echo $*
+  exit 1
+}
+
+[ -x "$(which curl)" ] || die "needs curl"
+[ -x "$(which jq)" ] || die "needs jq"
+[ -x "$(which pup)" ] || die "needs pup"
+
+curl -s http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html | pup 'table json{}' | jq -r '.[2].children[0].children[]|"      \"\(.children[0].children[0].text)\": { \"Ami\": \"\(.children[1].children[0].text)\" },"' | grep -v "null" 
+
+echo

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/convox/praxis/helpers"
@@ -23,14 +22,14 @@ import (
 var (
 	Rack rack.Rack
 
-	flagApp      string
-	flagAuth     string
-	flagId       string
-	flagManifest string
-	flagPrefix   string
-	flagPush     string
-	flagStage    int
-	flagUrl      string
+	flagApp         string
+	flagAuth        string
+	flagDevelopment bool
+	flagId          string
+	flagManifest    string
+	flagPrefix      string
+	flagPush        string
+	flagUrl         string
 
 	output bytes.Buffer
 	w      io.Writer
@@ -50,11 +49,11 @@ func init() {
 func main() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.StringVar(&flagApp, "app", "", "app name")
+	fs.BoolVar(&flagDevelopment, "development", false, "development build")
 	fs.StringVar(&flagId, "id", "", "build id")
 	fs.StringVar(&flagManifest, "manifest", "convox.yml", "path to manifest")
 	fs.StringVar(&flagPrefix, "prefix", "", "image prefix")
 	fs.StringVar(&flagPush, "push", "", "push after build")
-	fs.IntVar(&flagStage, "stage", 0, "release stage")
 	fs.StringVar(&flagUrl, "url", "", "source url")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -63,6 +62,10 @@ func main() {
 
 	if v := os.Getenv("BUILD_APP"); v != "" {
 		flagApp = v
+	}
+
+	if v := os.Getenv("BUILD_DEVELOPMENT"); v != "" {
+		flagDevelopment = (v == "true")
 	}
 
 	if v := os.Getenv("BUILD_ID"); v != "" {
@@ -81,17 +84,12 @@ func main() {
 		flagPush = v
 	}
 
-	if v := os.Getenv("BUILD_STAGE"); v != "" {
-		s, err := strconv.Atoi(v)
-		if err != nil {
-			fail(err)
-		}
-		flagStage = s
-	}
-
 	if v := os.Getenv("BUILD_URL"); v != "" {
 		flagUrl = v
 	}
+
+	// fmt.Printf("os.Environ() = %+v\n", os.Environ())
+	// fmt.Printf("flagDevelopment = %+v\n", flagDevelopment)
 
 	if err := auth(); err != nil {
 		fail(err)
@@ -179,56 +177,57 @@ func build() error {
 		return err
 	}
 
-	cache, err := ioutil.TempDir("", "")
-	if err != nil {
-		return err
-	}
+	// cache, err := ioutil.TempDir("", "")
+	// if err != nil {
+	//   return err
+	// }
 
-	ce, err := Rack.ObjectExists(flagApp, "convox/cache/build.tgz")
-	if err != nil {
-		return err
-	}
+	// ce, err := Rack.ObjectExists(flagApp, "convox/cache/build.tgz")
+	// if err != nil {
+	//   return err
+	// }
 
-	if ce {
-		fmt.Fprintf(w, "restoring cache\n")
+	// if ce {
+	//   fmt.Fprintf(w, "restoring cache\n")
 
-		cr, err := Rack.ObjectFetch(flagApp, "convox/cache/build.tgz")
-		if err != nil {
-			return err
-		}
+	//   cr, err := Rack.ObjectFetch(flagApp, "convox/cache/build.tgz")
+	//   if err != nil {
+	//     return err
+	//   }
 
-		defer cr.Close()
+	//   defer cr.Close()
 
-		if err := helpers.ExtractTarball(cr, cache); err != nil {
-			return err
-		}
-	}
+	//   if err := helpers.ExtractTarball(cr, cache); err != nil {
+	//     return err
+	//   }
+	// }
 
 	opts := manifest.BuildOptions{
-		Cache:  cache,
-		Env:    manifest.Environment(env),
-		Push:   flagPush,
-		Root:   tmp,
-		Stdout: w,
-		Stderr: w,
+		// Cache:  cache,
+		Development: flagDevelopment,
+		Env:         manifest.Environment(env),
+		Push:        flagPush,
+		Root:        tmp,
+		Stdout:      w,
+		Stderr:      w,
 	}
 
 	if err := m.Build(tmp, flagPrefix, flagId, opts); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(w, "saving cache\n")
+	// fmt.Fprintf(w, "saving cache\n")
 
-	tgz, err := helpers.CreateTarball(cache, helpers.TarballOptions{})
-	if err != nil {
-		return err
-	}
+	// tgz, err := helpers.CreateTarball(cache, helpers.TarballOptions{})
+	// if err != nil {
+	//   return err
+	// }
 
-	defer tgz.Close()
+	// defer tgz.Close()
 
-	if _, err := Rack.ObjectStore(flagApp, "convox/cache/build.tgz", tgz, types.ObjectStoreOptions{}); err != nil {
-		return err
-	}
+	// if _, err := Rack.ObjectStore(flagApp, "convox/cache/build.tgz", tgz, types.ObjectStoreOptions{}); err != nil {
+	//   return err
+	// }
 
 	fmt.Fprintf(w, "storing artifacts\n")
 
@@ -249,7 +248,7 @@ func build() error {
 }
 
 func release() error {
-	release, err := Rack.ReleaseCreate(flagApp, types.ReleaseCreateOptions{Build: flagId, Stage: flagStage})
+	release, err := Rack.ReleaseCreate(flagApp, types.ReleaseCreateOptions{Build: flagId})
 	if err != nil {
 		return err
 	}

--- a/cmd/cx/init.go
+++ b/cmd/cx/init.go
@@ -140,13 +140,11 @@ func ManifestConvert(mOld *mv1.Manifest) (*manifest.Manifest, Report, error) {
 		}
 
 		// command
-		var cmd manifest.ServiceCommand
+		var cmd string
 		if len(service.Command.Array) > 0 {
-			cmd.Development = shellquote.Join(service.Command.Array...)
-			cmd.Production = shellquote.Join(service.Command.Array...)
+			cmd = shellquote.Join(service.Command.Array...)
 		} else {
-			cmd.Development = service.Command.String
-			cmd.Production = service.Command.String
+			cmd = service.Command.String
 		}
 
 		// entrypoint

--- a/cmd/cx/init_test.go
+++ b/cmd/cx/init_test.go
@@ -34,11 +34,7 @@ func TestManifestConvert(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Path: ".",
 				},
-				Command: manifest.ServiceCommand{
-					Development: "bin/web",
-					Production:  "bin/web",
-					Test:        "",
-				},
+				Command: "bin/web",
 				Environment: []string{
 					"BAZ",
 					"FOO=bar",
@@ -72,11 +68,7 @@ func TestManifestConvert(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Path: ".",
 				},
-				Command: manifest.ServiceCommand{
-					Development: "bin/work",
-					Test:        "",
-					Production:  "bin/work",
-				},
+				Command:     "bin/work",
 				Environment: []string{},
 				Health: manifest.ServiceHealth{
 					Path:     "/",

--- a/cmd/cx/start.go
+++ b/cmd/cx/start.go
@@ -67,7 +67,7 @@ func runStart(c *cli.Context) error {
 		return err
 	}
 
-	b, err := buildDirectory(app, ".", types.BuildCreateOptions{Stage: manifest.StageDevelopment}, m.Writer("build", os.Stdout))
+	b, err := buildDirectory(app, ".", types.BuildCreateOptions{Development: true}, m.Writer("build", os.Stdout))
 	if err != nil {
 		return err
 	}

--- a/cmd/cx/test.go
+++ b/cmd/cx/test.go
@@ -68,19 +68,19 @@ func runTest(c *cli.Context) error {
 		return err
 	}
 
-	build, err := buildDirectory(app.Name, ".", types.BuildCreateOptions{Stage: manifest.StageTest}, m.Writer("build", os.Stdout))
+	build, err := buildDirectory(app.Name, ".", types.BuildCreateOptions{Development: true}, m.Writer("build", os.Stdout))
 	if err != nil {
 		return err
 	}
 
 	for _, s := range m.Services {
-		if s.Command.Test == "" {
+		if s.Test == "" {
 			continue
 		}
 
 		w := m.Writer(s.Name, os.Stdout)
 
-		if err := w.Writef("running: %s\n", s.Command.Test); err != nil {
+		if err := w.Writef("running: %s\n", s.Test); err != nil {
 			return err
 		}
 
@@ -90,7 +90,7 @@ func runTest(c *cli.Context) error {
 		}
 
 		code, err := Rack.ProcessRun(app.Name, types.ProcessRunOptions{
-			Command:     s.Command.Test,
+			Command:     s.Test,
 			Environment: senv,
 			Release:     build.Release,
 			Service:     s.Name,

--- a/convox.yml
+++ b/convox.yml
@@ -1,9 +1,6 @@
 services:
   rack:
     build: .
-    command:
-      development: env DEVELOPMENT=true rerun -watch . -build github.com/convox/praxis/cmd/rack
-      test: make test
     environment:
       - AWS_REGION=
       - AWS_ACCESS_KEY_ID=
@@ -14,7 +11,6 @@ services:
       - VERSION=
     port: https:3000
     scale:
-      count: 1
       memory: 256
     test: make test
     volumes:
@@ -24,17 +20,12 @@ workflows:
   change:
     create:
       - test: staging
-      - create: staging/praxis-$branch
-      - deploy: staging/praxis-$branch
     update:
       - test: staging
-      - deploy: staging/praxis-$branch
-    close:
-      - delete: staging/praxis-$branch
   merge:
     demo:
       - deploy: demo/praxis-demo
     master:
       - test: staging
-      - app: staging/praxis-release
+      - deploy: staging/praxis-release
       - run: bin/release

--- a/manifest/build.go
+++ b/manifest/build.go
@@ -18,12 +18,13 @@ import (
 )
 
 type BuildOptions struct {
-	Cache  string
-	Env    Environment
-	Push   string
-	Root   string
-	Stdout io.Writer
-	Stderr io.Writer
+	Cache       string
+	Development bool
+	Env         Environment
+	Push        string
+	Root        string
+	Stdout      io.Writer
+	Stderr      io.Writer
 }
 
 type BuildSource struct {
@@ -337,16 +338,27 @@ func build(b ServiceBuild, tag string, opts BuildOptions) error {
 		return err
 	}
 
-	ba, err := buildArgs(filepath.Join(path, "Dockerfile"))
+	df := filepath.Join(path, "Dockerfile")
+
+	if opts.Development {
+		data, err := ioutil.ReadFile(df)
+		if err != nil {
+			return err
+		}
+
+		dev := bytes.SplitN(data, []byte("## convox:production"), 2)
+
+		if err := ioutil.WriteFile(df, dev[0], 0644); err != nil {
+			return err
+		}
+	}
+
+	ba, err := buildArgs(df, opts)
 	if err != nil {
 		return err
 	}
 
-	for _, a := range ba {
-		if v, ok := opts.Env[a]; ok {
-			args = append(args, "--build-arg", fmt.Sprintf("%s=%s", a, v))
-		}
-	}
+	args = append(args, ba...)
 
 	args = append(args, path)
 
@@ -355,7 +367,7 @@ func build(b ServiceBuild, tag string, opts BuildOptions) error {
 	return opts.docker(args...)
 }
 
-func buildArgs(dockerfile string) ([]string, error) {
+func buildArgs(dockerfile string, opts BuildOptions) ([]string, error) {
 	fd, err := os.Open(dockerfile)
 	if err != nil {
 		return nil, err
@@ -376,8 +388,15 @@ func buildArgs(dockerfile string) ([]string, error) {
 		parts := strings.Split(fields[1], "=")
 
 		switch fields[0] {
+		case "FROM":
+			if opts.Development && strings.Contains(strings.ToLower(s.Text()), "as development") {
+				args = append(args, "--target", "development")
+			}
 		case "ARG":
-			args = append(args, strings.TrimSpace(parts[0]))
+			k := strings.TrimSpace(parts[0])
+			if v, ok := opts.Env[k]; ok {
+				args = append(args, "--build-args", fmt.Sprintf("%s=%s", k, v))
+			}
 		}
 	}
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -9,12 +9,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const (
-	StageProduction  = 0
-	StageDevelopment = iota
-	StageTest        = iota
-)
-
 type Manifest struct {
 	Balancers   Balancers   `yaml:"balancers,omitempty"`
 	Environment Environment `yaml:"environment,omitempty"`

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -15,24 +15,6 @@ func TestManifestLoad(t *testing.T) {
 	}
 
 	n := &manifest.Manifest{
-		Balancers: manifest.Balancers{
-			manifest.Balancer{
-				Name: "api",
-				Endpoints: manifest.BalancerEndpoints{
-					manifest.BalancerEndpoint{Port: "80", Protocol: "http", Redirect: "https://:443"},
-					manifest.BalancerEndpoint{Port: "443", Protocol: "https", Target: "http://api:3000"},
-				},
-			},
-			manifest.Balancer{
-				Name: "proxy",
-				Endpoints: manifest.BalancerEndpoints{
-					manifest.BalancerEndpoint{Port: "80", Target: "proxy:3001"},
-					manifest.BalancerEndpoint{Port: "443", Target: "proxy:3002"},
-					manifest.BalancerEndpoint{Port: "1080", Target: "proxy:3003"},
-					manifest.BalancerEndpoint{Port: "2133", Target: "proxy:3000"},
-				},
-			},
-		},
 		Environment: manifest.Environment{
 			"FOO":    "bar",
 			"SECRET": "shh",
@@ -60,11 +42,7 @@ func TestManifestLoad(t *testing.T) {
 					Path: "api",
 				},
 				Certificate: "foo.example.org",
-				Command: manifest.ServiceCommand{
-					Development: "rerun bar github.com/convox/praxis",
-					Test:        "make  test",
-					Production:  "",
-				},
+				Command:     "",
 				Environment: []string{
 					"DEVELOPMENT=false",
 					"SECRET",
@@ -74,18 +52,17 @@ func TestManifestLoad(t *testing.T) {
 					Interval: 10,
 					Timeout:  9,
 				},
+				Port:      manifest.ServicePort{Port: 1000, Scheme: "http"},
 				Resources: []string{"database"},
 				Scale: manifest.ServiceScale{
 					Count:  &manifest.ServiceScaleCount{Min: 3, Max: 10},
 					Memory: 256,
 				},
+				Test: "make  test",
 			},
 			manifest.Service{
-				Name: "proxy",
-				Command: manifest.ServiceCommand{
-					Development: "bash",
-					Production:  "bash",
-				},
+				Name:    "proxy",
+				Command: "bash",
 				Health: manifest.ServiceHealth{
 					Path:     "/auth",
 					Interval: 5,
@@ -95,6 +72,7 @@ func TestManifestLoad(t *testing.T) {
 				Environment: []string{
 					"SECRET",
 				},
+				Port: manifest.ServicePort{Port: 2000, Scheme: "https"},
 				Scale: manifest.ServiceScale{
 					Count:  &manifest.ServiceScaleCount{Min: 1, Max: 1},
 					Memory: 512,
@@ -105,15 +83,13 @@ func TestManifestLoad(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Path: ".",
 				},
-				Command: manifest.ServiceCommand{
-					Development: "foo",
-					Production:  "foo",
-				},
+				Command: "foo",
 				Health: manifest.ServiceHealth{
 					Interval: 5,
 					Path:     "/",
 					Timeout:  3,
 				},
+				Port: manifest.ServicePort{Port: 3000, Scheme: "https"},
 				Scale: manifest.ServiceScale{
 					Count:  &manifest.ServiceScaleCount{Min: 0, Max: 0},
 					Memory: 256,
@@ -124,7 +100,7 @@ func TestManifestLoad(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Path: ".",
 				},
-				Command: manifest.ServiceCommand{},
+				Command: "",
 				Health: manifest.ServiceHealth{
 					Interval: 5,
 					Path:     "/",

--- a/manifest/service.go
+++ b/manifest/service.go
@@ -8,16 +8,17 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Build       ServiceBuild   `yaml:"build,omitempty"`
-	Certificate string         `yaml:"certificate,omitempty"`
-	Command     ServiceCommand `yaml:"command,omitempty"`
-	Environment []string       `yaml:"environment,omitempty"`
-	Health      ServiceHealth  `yaml:"health,omitempty"`
-	Image       string         `yaml:"image,omitempty"`
-	Port        ServicePort    `yaml:"port,omitempty"`
-	Resources   []string       `yaml:"resources,omitempty"`
-	Scale       ServiceScale   `yaml:"scale,omitempty"`
-	Volumes     []string       `yaml:"volumes,omitempty"`
+	Build       ServiceBuild  `yaml:"build,omitempty"`
+	Certificate string        `yaml:"certificate,omitempty"`
+	Command     string        `yaml:"command,omitempty"`
+	Environment []string      `yaml:"environment,omitempty"`
+	Health      ServiceHealth `yaml:"health,omitempty"`
+	Image       string        `yaml:"image,omitempty"`
+	Port        ServicePort   `yaml:"port,omitempty"`
+	Resources   []string      `yaml:"resources,omitempty"`
+	Scale       ServiceScale  `yaml:"scale,omitempty"`
+	Test        string        `yaml:"test,omitempty"`
+	Volumes     []string      `yaml:"volumes,omitempty"`
 }
 
 type Services []Service

--- a/manifest/test.go
+++ b/manifest/test.go
@@ -9,8 +9,8 @@ type TestOptions struct {
 
 func (m *Manifest) Test(ns string, opts TestOptions) error {
 	for _, s := range m.Services {
-		if s.Command.Test != "" {
-			err := s.run(ns, s.Command.Test, RunOptions{
+		if s.Test != "" {
+			err := s.run(ns, s.Test, RunOptions{
 				Stdout: opts.Stdout,
 				Stderr: opts.Stderr,
 			})

--- a/manifest/testdata/full.yml
+++ b/manifest/testdata/full.yml
@@ -1,12 +1,3 @@
-balancers:
-  api:
-    80/http/301: https://:443
-    443/https: http://api:3000
-  proxy:
-    80: proxy:3001
-    443: proxy:3002
-    1080: proxy:3003
-    2133: proxy:3000
 keys:
   master:
 queues:
@@ -19,9 +10,6 @@ services:
     build:
       path: api
     certificate: foo.example.org
-    command:
-      development: rerun ${FOO} github.com/convox/praxis
-      test: make ${BAR} test
     environment:
       - DEVELOPMENT=false
       - SECRET
@@ -29,19 +17,25 @@ services:
       interval: 10
     resources:
       - database
+    port: 1000
     scale: 3-10
+    test: make ${BAR} test
   proxy:
     command: bash
     image: ubuntu:16.04
     environment:
       - SECRET
     health: /auth
+    port: https:2000
     scale:
       memory: 512
   foo:
     command: foo
     health:
       timeout: 3
+    port:
+      scheme: https
+      port: 3000
     scale: 0
   bar:
 tables:

--- a/manifest/yaml.go
+++ b/manifest/yaml.go
@@ -268,6 +268,9 @@ func (v *ServicePort) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		default:
 			return fmt.Errorf("invalid port: %s", t)
 		}
+	case int:
+		v.Scheme = "http"
+		v.Port = t
 	default:
 		return fmt.Errorf("invalid port: %s", t)
 	}

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -267,8 +267,8 @@
       {{ end }}
       "Properties": {
         "ContainerDefinitions": [ {
-          {{ if .Command.Production }}
-            "Command": [ "sh", "-c", "{{ .Command.Production }}" ],
+          {{ with .Command }}
+            "Command": [ "sh", "-c", "{{ . }}" ],
           {{ end }}
           "DockerLabels": {
             "convox.app": "{{ $.App.Name }}",

--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -10,17 +10,17 @@
       }
     },
     "RegionConfig": {
-      "us-east-1": { "Ami": "ami-d69c74c0" },
-      "us-east-2": { "Ami": "ami-64270201" },
-      "us-west-1": { "Ami": "ami-bc90c2dc" },
-      "us-west-2": { "Ami": "ami-8e7bc4ee" },
-      "eu-west-1": { "Ami": "ami-48f9a52e" },
-      "eu-west-2": { "Ami": "ami-62aea406" },
-      "eu-central-1": { "Ami": "ami-6b428d04" },
-      "ap-northeast-1": { "Ami": "ami-372f5450" },
-      "ap-southeast-1": { "Ami": "ami-69208a0a" },
-      "ap-southeast-2": { "Ami": "ami-307f7853" },
-      "ca-central-1": { "Ami": "ami-b2e65bd6" }
+      "us-east-1": { "Ami": "ami-275ffe31" },
+      "us-east-2": { "Ami": "ami-62745007" },
+      "us-west-1": { "Ami": "ami-689bc208" },
+      "us-west-2": { "Ami": "ami-62d35c02" },
+      "eu-west-1": { "Ami": "ami-95f8d2f3" },
+      "eu-west-2": { "Ami": "ami-bf9481db" },
+      "eu-central-1": { "Ami": "ami-085e8a67" },
+      "ap-northeast-1": { "Ami": "ami-f63f6f91" },
+      "ap-southeast-1": { "Ami": "ami-b4ae1dd7" },
+      "ap-southeast-2": { "Ami": "ami-fbe9eb98" },
+      "ca-central-1": { "Ami": "ami-ee58e58a" }
     }
   },
   "Outputs": {

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"strconv"
 	"strings"
 	"time"
 
@@ -30,8 +29,6 @@ func (p *Provider) ReleaseCreate(app string, opts types.ReleaseCreateOptions) (*
 	if opts.Env != nil {
 		r.Env = opts.Env
 	}
-
-	r.Stage = opts.Stage
 
 	if err := p.releaseStore(r); err != nil {
 		return nil, err
@@ -293,12 +290,6 @@ func (p *Provider) releaseFromAttributes(id string, attrs []*simpledb.Attribute)
 					return nil, err
 				}
 			}
-		case "stage":
-			s, err := strconv.Atoi(*attr.Value)
-			if err != nil {
-				return nil, err
-			}
-			release.Stage = s
 		case "status":
 			release.Status = *attr.Value
 		}
@@ -338,7 +329,6 @@ func (p *Provider) releaseStore(release *types.Release) error {
 		{Replace: aws.Bool(true), Name: aws.String("app"), Value: aws.String(release.App)},
 		{Replace: aws.Bool(true), Name: aws.String("build"), Value: aws.String(release.Build)},
 		{Replace: aws.Bool(true), Name: aws.String("created"), Value: aws.String(release.Created.Format(helpers.SortableTime))},
-		{Replace: aws.Bool(true), Name: aws.String("stage"), Value: aws.String(strconv.Itoa(release.Stage))},
 		{Replace: aws.Bool(true), Name: aws.String("status"), Value: aws.String(release.Status)},
 	}
 

--- a/provider/local/build.go
+++ b/provider/local/build.go
@@ -59,13 +59,15 @@ func (p *Provider) BuildCreate(app, url string, opts types.BuildCreateOptions) (
 	buildUpdateLock.Lock()
 	defer buildUpdateLock.Unlock()
 
+	fmt.Printf("opts = %+v\n", opts)
+
 	pid, err := p.ProcessStart(app, types.ProcessRunOptions{
 		Command: fmt.Sprintf("build -id %s -url %s", id, url),
 		Environment: map[string]string{
-			"BUILD_APP":    app,
-			"BUILD_AUTH":   base64.StdEncoding.EncodeToString(auth),
-			"BUILD_PREFIX": fmt.Sprintf("%s/%s", p.Name, app),
-			"BUILD_STAGE":  fmt.Sprintf("%d", opts.Stage),
+			"BUILD_APP":         app,
+			"BUILD_AUTH":        base64.StdEncoding.EncodeToString(auth),
+			"BUILD_DEVELOPMENT": fmt.Sprintf("%t", opts.Development),
+			"BUILD_PREFIX":      fmt.Sprintf("%s/%s", p.Name, app),
 		},
 		Name:    fmt.Sprintf("%s-build-%s", app, id),
 		Image:   sys.Image,

--- a/provider/local/release.go
+++ b/provider/local/release.go
@@ -35,8 +35,6 @@ func (p *Provider) ReleaseCreate(app string, opts types.ReleaseCreateOptions) (*
 		r.Env = opts.Env
 	}
 
-	r.Stage = opts.Stage
-
 	if err := p.storageStore(fmt.Sprintf("apps/%s/releases/%s/release.json", app, r.Id), r); err != nil {
 		return nil, errors.WithStack(log.Error(err))
 	}

--- a/sdk/rack/build.go
+++ b/sdk/rack/build.go
@@ -3,7 +3,6 @@ package rack
 import (
 	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/convox/praxis/types"
 )
@@ -11,8 +10,9 @@ import (
 func (c *Client) BuildCreate(app, url string, opts types.BuildCreateOptions) (build *types.Build, err error) {
 	ro := RequestOptions{
 		Params: Params{
-			"stage": strconv.Itoa(opts.Stage),
-			"url":   url,
+			"cache":       fmt.Sprintf("%t", opts.Cache),
+			"development": fmt.Sprintf("%t", opts.Development),
+			"url":         url,
 		},
 	}
 

--- a/sdk/rack/client.go
+++ b/sdk/rack/client.go
@@ -55,7 +55,7 @@ func (o *RequestOptions) Reader() (io.Reader, error) {
 	}
 
 	if o.Body == nil && len(o.Params) == 0 {
-		return nil, nil
+		return bytes.NewReader(nil), nil
 	}
 
 	if o.Body != nil {
@@ -127,7 +127,9 @@ func (c *Client) Stream(path string, opts RequestOptions) (io.ReadCloser, error)
 			return nil, err
 		}
 
-		go io.Copy(ws, r)
+		if r != nil {
+			go io.Copy(ws, r)
+		}
 
 		return ws, nil
 	case "http2":

--- a/sdk/rack/release.go
+++ b/sdk/rack/release.go
@@ -19,7 +19,6 @@ func (c *Client) ReleaseCreate(app string, opts types.ReleaseCreateOptions) (rel
 		Params: Params{
 			"build": opts.Build,
 			"env":   string(data),
-			"stage": strconv.Itoa(opts.Stage),
 		},
 	}
 

--- a/server/controllers/build.go
+++ b/server/controllers/build.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"net/http"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/convox/praxis/api"
@@ -13,15 +12,13 @@ import (
 
 func BuildCreate(w http.ResponseWriter, r *http.Request, c *api.Context) error {
 	app := c.Var("app")
-	url := c.Form("url")
 	cache := c.Form("cache") == "true"
+	development := c.Form("development") == "true"
+	url := c.Form("url")
 
 	opts := types.BuildCreateOptions{
-		Cache: cache,
-	}
-
-	if s, err := strconv.Atoi(c.Form("stage")); err == nil {
-		opts.Stage = s
+		Cache:       cache,
+		Development: development,
 	}
 
 	build, err := Provider.WithContext(c.Context()).BuildCreate(app, url, opts)

--- a/server/controllers/process.go
+++ b/server/controllers/process.go
@@ -28,9 +28,7 @@ func ProcessExec(rw io.ReadWriteCloser, c *api.Context) error {
 		Output: rw,
 	}
 
-	if c.Header("Input") == "true" {
-		opts.Input = rw
-	}
+	opts.Input = ioutil.NopCloser(rw)
 
 	if height != "" {
 		h, err := strconv.Atoi(height)
@@ -194,9 +192,7 @@ func ProcessRun(rw io.ReadWriteCloser, c *api.Context) error {
 		Output:      rw,
 	}
 
-	if c.Header("Input") == "true" {
-		opts.Input = ioutil.NopCloser(rw)
-	}
+	opts.Input = ioutil.NopCloser(rw)
 
 	if height != "" {
 		h, err := strconv.Atoi(height)

--- a/server/controllers/release.go
+++ b/server/controllers/release.go
@@ -35,10 +35,6 @@ func ReleaseCreate(w http.ResponseWriter, r *http.Request, c *api.Context) error
 		opts.Env = env
 	}
 
-	if s, err := strconv.Atoi(c.Form("stage")); err == nil {
-		opts.Stage = s
-	}
-
 	release, err := Provider.ReleaseCreate(app, opts)
 	if err != nil {
 		return err

--- a/types/build.go
+++ b/types/build.go
@@ -18,9 +18,9 @@ type Build struct {
 type Builds []Build
 
 type BuildCreateOptions struct {
-	Cache    bool
-	Manifest string
-	Stage    int
+	Development bool
+	Cache       bool
+	Manifest    string
 }
 
 type BuildUpdateOptions struct {

--- a/types/release.go
+++ b/types/release.go
@@ -10,7 +10,6 @@ type Release struct {
 	App    string      `json:"app"`
 	Build  string      `json:"build"`
 	Env    Environment `json:"env"`
-	Stage  int         `json:"stage"`
 	Status string      `json:"status"`
 
 	Created time.Time `json:"created"`
@@ -21,7 +20,6 @@ type Releases []Release
 type ReleaseCreateOptions struct {
 	Build string
 	Env   map[string]string
-	Stage int
 }
 
 type ReleaseListOptions struct {


### PR DESCRIPTION
Would like to use Docker multi-stage here but getting it working with ECS is painful.

We're using a special comment in the Dockerfile for now:

```Dockerfile
FROM convox/golang
ENV DEVELOPMENT=true
WORKDIR $GOPATH/src/github.com/convox/praxis
COPY . .
CMD ["rerun", "-watch", ".", "-build", "github.com/convox/praxis/cmd/rack"]

## convox:production

ENV DEVELOPMENT=false
WORKDIR $GOPATH/src/github.com/convox/praxis
RUN go install ./cmd/...
CMD ["rack"]
```

Everything below the `## convox:production` does not run in development mode.

This pull request also removes the sub-keys from `command:` and turns it back into just a string.

The test command is now defined at the service level with a `test:` key.