### PR TITLE
make sure migrated service order is deterministic

### DIFF
--- a/cmd/cx/init.go
+++ b/cmd/cx/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -99,7 +100,15 @@ func ManifestConvert(mOld *mv1.Manifest) (*manifest.Manifest, Report, error) {
 	services := manifest.Services{}
 	timers := make(manifest.Timers, 0)
 
-	for name, service := range mOld.Services {
+	sk := make([]string, 0)
+	for k, _ := range mOld.Services {
+		sk = append(sk, k)
+	}
+	sort.Strings(sk)
+
+	for _, k := range sk {
+		service := mOld.Services[k]
+
 		// resources
 		serviceResources := []string{}
 		if resourceService(service) {
@@ -287,7 +296,7 @@ func ManifestConvert(mOld *mv1.Manifest) (*manifest.Manifest, Report, error) {
 		}
 
 		s := manifest.Service{
-			Name:        name,
+			Name:        k,
 			Build:       b,
 			Command:     cmd,
 			Environment: env,

--- a/cmd/cx/init_test.go
+++ b/cmd/cx/init_test.go
@@ -101,6 +101,7 @@ func TestManifestConvert(t *testing.T) {
 
 	r := cx.Report{
 		Messages: []string{
+			"INFO: <service>database</service> has been migrated to a resource\n",
 			"<fail>FAIL</fail>: <service>web</service> build args not migrated to convox.yml, use ARG in your Dockerfile instead\n",
 			"<fail>FAIL</fail>: <service>web</service> \"dockerfile\" key is not supported in convox.yml, file must be named \"Dockerfile\"\n",
 			"<fail>FAIL</fail>: <service>web</service> \"entrypoint\" key not supported in convox.yml, use ENTRYPOINT in Dockerfile instead\n",
@@ -118,7 +119,6 @@ func TestManifestConvert(t *testing.T) {
 			"INFO: <service>web</service> - UDP ports are not supported\n",
 			"INFO: <service>web</service> - only HTTP ports supported\n",
 			"INFO: <service>web</service> - privileged mode not supported\n",
-			"INFO: <service>database</service> has been migrated to a resource\n",
 			"INFO: custom networks not supported, use service hostnames instead\n",
 		},
 		Success: false,


### PR DESCRIPTION
This prevents random test failures caused by iterating over convox/rack's Service map.