### PR TITLE
cx test environment

### DIFF
--- a/cmd/cx/init.go
+++ b/cmd/cx/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -99,7 +100,15 @@ func ManifestConvert(mOld *mv1.Manifest) (*manifest.Manifest, Report, error) {
 	services := manifest.Services{}
 	timers := make(manifest.Timers, 0)
 
-	for name, service := range mOld.Services {
+	sk := make([]string, 0)
+	for k, _ := range mOld.Services {
+		sk = append(sk, k)
+	}
+	sort.Strings(sk)
+
+	for _, k := range sk {
+		service := mOld.Services[k]
+
 		// resources
 		serviceResources := []string{}
 		if resourceService(service) {
@@ -287,7 +296,7 @@ func ManifestConvert(mOld *mv1.Manifest) (*manifest.Manifest, Report, error) {
 		}
 
 		s := manifest.Service{
-			Name:        name,
+			Name:        k,
 			Build:       b,
 			Command:     cmd,
 			Environment: env,

--- a/cmd/cx/init_test.go
+++ b/cmd/cx/init_test.go
@@ -101,6 +101,7 @@ func TestManifestConvert(t *testing.T) {
 
 	r := cx.Report{
 		Messages: []string{
+			"INFO: <service>database</service> has been migrated to a resource\n",
 			"<fail>FAIL</fail>: <service>web</service> build args not migrated to convox.yml, use ARG in your Dockerfile instead\n",
 			"<fail>FAIL</fail>: <service>web</service> \"dockerfile\" key is not supported in convox.yml, file must be named \"Dockerfile\"\n",
 			"<fail>FAIL</fail>: <service>web</service> \"entrypoint\" key not supported in convox.yml, use ENTRYPOINT in Dockerfile instead\n",
@@ -118,7 +119,6 @@ func TestManifestConvert(t *testing.T) {
 			"INFO: <service>web</service> - UDP ports are not supported\n",
 			"INFO: <service>web</service> - only HTTP ports supported\n",
 			"INFO: <service>web</service> - privileged mode not supported\n",
-			"INFO: <service>database</service> has been migrated to a resource\n",
 			"INFO: custom networks not supported, use service hostnames instead\n",
 		},
 		Success: false,

--- a/cmd/cx/test.go
+++ b/cmd/cx/test.go
@@ -77,6 +77,19 @@ func runTest(c *cli.Context) error {
 		return err
 	}
 
+	if err := releaseLogs(app.Name, build.Release, m.Writer("release", os.Stdout), types.LogsOptions{Follow: true}); err != nil {
+		return err
+	}
+
+	r, err := Rack.ReleaseGet(app.Name, build.Release)
+	if err != nil {
+		return err
+	}
+
+	if r.Status != "promoted" {
+		return fmt.Errorf("promote failed")
+	}
+
 	for _, s := range m.Services {
 		if s.Test == "" {
 			continue

--- a/cmd/cx/test.go
+++ b/cmd/cx/test.go
@@ -73,6 +73,10 @@ func runTest(c *cli.Context) error {
 		return err
 	}
 
+	if err := Rack.ReleasePromote(app.Name, build.Release); err != nil {
+		return err
+	}
+
 	for _, s := range m.Services {
 		if s.Test == "" {
 			continue

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -734,6 +734,18 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 		})
 	}
 
+	req.ContainerDefinitions[0].MountPoints = append(req.ContainerDefinitions[0].MountPoints, &ecs.MountPoint{
+		ContainerPath: aws.String("/var/run/docker.sock"),
+		SourceVolume:  aws.String("docker"),
+	})
+
+	req.Volumes = append(req.Volumes, &ecs.Volume{
+		Host: &ecs.HostVolumeProperties{
+			SourcePath: aws.String("/var/run/docker.sock"),
+		},
+		Name: aws.String("docker"),
+	})
+
 	res, err := p.ECS().RegisterTaskDefinition(req)
 	if err != nil {
 		return "", err

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -723,6 +723,10 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 	for from, to := range opts.Volumes {
 		name := fmt.Sprintf("volume-%d", i)
 
+		if from == "/var/run/docker.sock" && to == "/var/run/docker.sock" {
+			name = "docker"
+		}
+
 		req.ContainerDefinitions[0].MountPoints = append(req.ContainerDefinitions[0].MountPoints, &ecs.MountPoint{
 			ContainerPath: aws.String(to),
 			SourceVolume:  aws.String(name),
@@ -736,17 +740,19 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 		})
 	}
 
-	req.ContainerDefinitions[0].MountPoints = append(req.ContainerDefinitions[0].MountPoints, &ecs.MountPoint{
-		ContainerPath: aws.String("/var/run/docker.sock"),
-		SourceVolume:  aws.String("docker"),
-	})
+	// req.ContainerDefinitions[0].MountPoints = append(req.ContainerDefinitions[0].MountPoints, &ecs.MountPoint{
+	// 	ContainerPath: aws.String("/var/run/docker.sock"),
+	// 	SourceVolume:  aws.String("docker"),
+	// })
 
-	req.Volumes = append(req.Volumes, &ecs.Volume{
-		Host: &ecs.HostVolumeProperties{
-			SourcePath: aws.String("/var/run/docker.sock"),
-		},
-		Name: aws.String("docker"),
-	})
+	// req.Volumes = append(req.Volumes, &ecs.Volume{
+	// 	Host: &ecs.HostVolumeProperties{
+	// 		SourcePath: aws.String("/var/run/docker.sock"),
+	// 	},
+	// 	Name: aws.String("docker"),
+	// })
+
+	fmt.Printf("REQ: %+v\n", req)
 
 	res, err := p.ECS().RegisterTaskDefinition(req)
 	if err != nil {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -583,8 +583,6 @@ func (p *Provider) fetchTaskDefinition(arn string) (*ecs.TaskDefinition, error) 
 }
 
 func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (string, error) {
-	fmt.Printf("OPTS: %+v\n", opts)
-
 	logs, err := p.appResource(app, "Logs")
 	if err != nil {
 		return "", err
@@ -771,8 +769,6 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 			SourceVolume:  aws.String(name),
 		})
 	}
-
-	fmt.Printf("REQ: %+v\n", req)
 
 	res, err := p.ECS().RegisterTaskDefinition(req)
 	if err != nil {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -670,6 +670,11 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 			return "", fmt.Errorf("no release for app: %s", app)
 		}
 
+		req.ContainerDefinitions[0].Environment = append(req.ContainerDefinitions[0].Environment, &ecs.KeyValuePair{
+			Name:  aws.String("RELEASE"),
+			Value: aws.String(opts.Release),
+		})
+
 		account, err := p.accountID()
 		if err != nil {
 			return "", err

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -654,18 +654,6 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 		})
 	}
 
-	rs, err := p.ResourceList(app)
-	if err != nil {
-		return "", err
-	}
-
-	for _, r := range rs {
-		req.ContainerDefinitions[0].Environment = append(req.ContainerDefinitions[0].Environment, &ecs.KeyValuePair{
-			Name:  aws.String(strings.ToUpper(fmt.Sprintf("%s_URL", r.Name))),
-			Value: aws.String(r.Endpoint),
-		})
-	}
-
 	if opts.Service != "" && opts.Image == "" {
 		if opts.Release == "" {
 			a, err := p.AppGet(app)
@@ -707,6 +695,20 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 
 	if opts.Image != "" {
 		req.ContainerDefinitions[0].Image = aws.String(opts.Image)
+	}
+
+	if opts.Release != "" {
+		rs, err := p.ResourceList(app)
+		if err != nil {
+			return "", err
+		}
+
+		for _, r := range rs {
+			req.ContainerDefinitions[0].Environment = append(req.ContainerDefinitions[0].Environment, &ecs.KeyValuePair{
+				Name:  aws.String(strings.ToUpper(fmt.Sprintf("%s_URL", r.Name))),
+				Value: aws.String(r.Endpoint),
+			})
+		}
 	}
 
 	for from, to := range opts.Ports {

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -654,6 +654,18 @@ func (p *Provider) taskDefinition(app string, opts types.ProcessRunOptions) (str
 		})
 	}
 
+	rs, err := p.ResourceList(app)
+	if err != nil {
+		return "", err
+	}
+
+	for _, r := range rs {
+		req.ContainerDefinitions[0].Environment = append(req.ContainerDefinitions[0].Environment, &ecs.KeyValuePair{
+			Name:  aws.String(strings.ToUpper(fmt.Sprintf("%s_URL", r.Name))),
+			Value: aws.String(r.Endpoint),
+		})
+	}
+
 	if opts.Service != "" && opts.Image == "" {
 		if opts.Release == "" {
 			a, err := p.AppGet(app)

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -306,6 +306,12 @@
             }
           },
           "Memory": "{{ .Scale.Memory }}",
+          "MountPoints": [
+            {
+              "ContainerPath": "/var/run/docker.sock",
+              "SourceVolume": "docker"
+            }
+          ],
           {{ with .Port.Port }}
             "PortMappings": [ { "ContainerPort": "{{ . }}", "Protocol": "tcp" } ],
           {{ end }}

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -201,6 +201,7 @@
 {{ end }}
 
 {{ define "services" }}
+  {{ $m := .Manifest }}
   {{ range $s := .Manifest.Services }}
     "Service{{ resource .Name }}": {
       "Type": "AWS::ECS::Service",
@@ -290,7 +291,7 @@
             {{ range .Resources }}
               { "Name": "{{ upper . }}_URL", "Value": { "Fn::GetAtt": [ "Resource{{resource . }}", "Outputs.Url" ] } },
             {{ end }}
-            {{ range $k, $v := $.Env }}
+            {{ range $k, $v := $m.ServiceEnvironment $s.Name }}
               { "Name": "{{ $k }}", "Value": "{{ safe $v }}" },
             {{ end }}
             { "Ref": "AWS::NoValue" }
@@ -307,10 +308,13 @@
           },
           "Memory": "{{ .Scale.Memory }}",
           "MountPoints": [
-            {
-              "ContainerPath": "/var/run/docker.sock",
-              "SourceVolume": "docker"
-            }
+            {{ range $i, $v := .Volumes }}
+              {
+                "ContainerPath": "{{ split $v ":" 1 }}",
+                "SourceVolume": "volume-{{ $i }}"
+              },
+            {{ end }}
+            { "Ref": "AWS::NoValue" }
           ],
           {{ with .Port.Port }}
             "PortMappings": [ { "ContainerPort": "{{ . }}", "Protocol": "tcp" } ],
@@ -319,7 +323,15 @@
         } ],
         "Family": { "Fn::Sub": "${AWS::StackName}-{{ .Name }}" },
         "TaskRoleArn": { "Ref": "Role" },
-        "Volumes": [ { "Name": "docker", "Host": { "SourcePath": "/var/run/docker.sock" } } ]
+        "Volumes": [
+            {{ range $i, $v := .Volumes }}
+              {
+                "Name": "volume-{{ $i }}",
+                "Host": { "SourcePath": "{{ split $v ":" 0 }}" }
+              },
+            {{ end }}
+            { "Ref": "AWS::NoValue" }
+        ]
       }
     },
   {{ end }}

--- a/provider/aws/formation/app.json.tmpl
+++ b/provider/aws/formation/app.json.tmpl
@@ -310,7 +310,7 @@
           "MountPoints": [
             {{ range $i, $v := .Volumes }}
               {
-                "ContainerPath": "{{ split $v ":" 1 }}",
+                "ContainerPath": "{{ volumeTo $v }}",
                 "SourceVolume": "volume-{{ $i }}"
               },
             {{ end }}
@@ -327,7 +327,7 @@
             {{ range $i, $v := .Volumes }}
               {
                 "Name": "volume-{{ $i }}",
-                "Host": { "SourcePath": "{{ split $v ":" 0 }}" }
+                "Host": { "SourcePath": "{{ volumeFrom $v }}" }
               },
             {{ end }}
             { "Ref": "AWS::NoValue" }

--- a/provider/aws/process.go
+++ b/provider/aws/process.go
@@ -256,7 +256,12 @@ func (p *Provider) ProcessStart(app string, opts types.ProcessRunOptions) (strin
 		return "", err
 	}
 	if len(res.Tasks) != 1 {
-		return "", fmt.Errorf("unable to start process")
+		msg := "unable to start process"
+		if len(res.Failures) > 0 {
+			msg = fmt.Sprintf("%s: %s", msg, *res.Failures[0].Reason)
+		}
+
+		return "", fmt.Errorf(msg)
 	}
 
 	parts := strings.Split(*res.Tasks[0].TaskArn, "/")

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -155,7 +155,6 @@ func (p *Provider) ReleasePromote(app string, id string) error {
 
 	tp := map[string]interface{}{
 		"App":      a,
-		"Env":      r.Env,
 		"Manifest": m,
 		"Release":  r,
 		"Version":  p.Version,

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -34,6 +34,13 @@ func formationHelpers() template.FuncMap {
 		"safe": func(s string) template.HTML {
 			return template.HTML(s)
 		},
+		"split": func(s, sep string, n int) string {
+			parts := strings.Split(s, sep)
+			if n < len(parts) {
+				return parts[n]
+			}
+			return fmt.Sprintf("missing part %d", n)
+		},
 		"upper": func(s string) string {
 			return strings.ToUpper(s)
 		},

--- a/provider/aws/template.go
+++ b/provider/aws/template.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 	"html/template"
 	"net"
+	"path"
 	"strings"
 )
 
@@ -34,15 +35,28 @@ func formationHelpers() template.FuncMap {
 		"safe": func(s string) template.HTML {
 			return template.HTML(s)
 		},
-		"split": func(s, sep string, n int) string {
-			parts := strings.Split(s, sep)
-			if n < len(parts) {
-				return parts[n]
-			}
-			return fmt.Sprintf("missing part %d", n)
-		},
 		"upper": func(s string) string {
 			return strings.ToUpper(s)
+		},
+		"volumeFrom": func(s string) string {
+			parts := strings.SplitN(s, ":", 2)
+			switch len(parts) {
+			case 1:
+				return path.Join("/volumes", s)
+			case 2:
+				return parts[0]
+			}
+			return fmt.Sprintf("invalid volume %q", s)
+		},
+		"volumeTo": func(s string) string {
+			parts := strings.SplitN(s, ":", 2)
+			switch len(parts) {
+			case 1:
+				return s
+			case 2:
+				return parts[1]
+			}
+			return fmt.Sprintf("invalid volume %q", s)
 		},
 	}
 }

--- a/provider/local/process.go
+++ b/provider/local/process.go
@@ -276,11 +276,12 @@ func (p *Provider) argsFromOpts(app string, opts types.ProcessRunOptions) ([]str
 		if err != nil {
 			return nil, err
 		}
+
 		for k, v := range env {
 			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 		}
 
-		// environment for resources
+		// resource environment
 		rs, err := p.ResourceList(app)
 		if err != nil {
 			return nil, err

--- a/provider/local/process.go
+++ b/provider/local/process.go
@@ -245,8 +245,6 @@ func (p *Provider) ProcessStop(app, pid string) error {
 }
 
 func (p *Provider) argsFromOpts(app string, opts types.ProcessRunOptions) ([]string, error) {
-	fmt.Printf("OPTS: %+v\n", opts)
-
 	args := []string{"run", "--rm", "-i"}
 
 	if opts.Input != nil {

--- a/provider/local/process.go
+++ b/provider/local/process.go
@@ -283,6 +283,19 @@ func (p *Provider) argsFromOpts(app string, opts types.ProcessRunOptions) ([]str
 		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 	}
 
+	if opts.Release != "" {
+		rs, err := p.ResourceList(app)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, r := range rs {
+			k := strings.ToUpper(fmt.Sprintf("%s_URL", r.Name))
+			v := r.Endpoint
+			args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
 	for k, v := range opts.Environment {
 		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 	}


### PR DESCRIPTION
Tracking down difference between `cx test` locally and on aws. This is proxy for consistent build / release / run behavior on both providers.

- [x] Promote the `cx test` release before run
- [x] In one-off processes, set proper environment including resources like DATABASE_URL
- [x] Add "host:container" volumes to services and one-offs on local and aws

This makes some assumptions and potentially breaking changes to environment and volume handling. See https://github.com/convox/praxis/issues/229 and https://github.com/convox/praxis/issues/230.
