### PR TITLE
30 min idle timeout

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -273,7 +273,7 @@
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Properties": {
         "LoadBalancerAttributes": [
-          { "Key" : "idle_timeout.timeout_seconds", "Value" : "600" }
+          { "Key" : "idle_timeout.timeout_seconds", "Value" : "1800" }
         ],
         "Scheme": "internet-facing",
         "SecurityGroups": [ { "Ref": "BalancerSecurity" } ],


### PR DESCRIPTION
Bump from 10 mins to 30. This prevents ALB from closing connection when streaming e.g release logs. This would cause

```
http2: server sent GOAWAY and closed the connection; LastStreamID=1, ErrCode=NO_ERROR, debug=""
``` 
on the server

```
stream error: stream ID 1; INTERNAL_ERROR
```
on the client