### PR TITLE
30 min idle timeout

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -273,7 +273,7 @@
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Properties": {
         "LoadBalancerAttributes": [
-          { "Key" : "idle_timeout.timeout_seconds", "Value" : "600" }
+          { "Key" : "idle_timeout.timeout_seconds", "Value" : "1800" }
         ],
         "Scheme": "internet-facing",
         "SecurityGroups": [ { "Ref": "BalancerSecurity" } ],


### PR DESCRIPTION
Pulling this out of https://github.com/convox/praxis/pull/232 and into it's own PR.

Increasing the ALB idle timeout helps with long-running connections. Specifically this makes `cx release` logs stable on long releases like those that create an RDS database.

Without this these releases consistently fail with:

```
release | UPDATE_IN_PROGRESS staging-test-1497892722 AWS::CloudFormation::Stack
release | CREATE_IN_PROGRESS QueueRacks AWS::SQS::Queue
release | CREATE_IN_PROGRESS KeyIntegrations AWS::KMS::Key
release | CREATE_IN_PROGRESS ServiceProxyTargetGroup AWS::ElasticLoadBalancingV2::TargetGroup
release | CREATE_IN_PROGRESS KeyRacks AWS::KMS::Key
release | CREATE_IN_PROGRESS ResourceDatabase AWS::CloudFormation::Stack
release | CREATE_IN_PROGRESS QueueRacks AWS::SQS::Queue
release | CREATE_IN_PROGRESS ServiceWebTargetGroup AWS::ElasticLoadBalancingV2::TargetGroup
release | CREATE_IN_PROGRESS KeyIntegrations AWS::KMS::Key
release | CREATE_IN_PROGRESS KeyRacks AWS::KMS::Key
release | CREATE_COMPLETE QueueRacks AWS::SQS::Queue
release | CREATE_IN_PROGRESS ServiceProxyTargetGroup AWS::ElasticLoadBalancingV2::TargetGroup
release | CREATE_IN_PROGRESS ServiceWebTargetGroup AWS::ElasticLoadBalancingV2::TargetGroup
release | CREATE_COMPLETE ServiceWebTargetGroup AWS::ElasticLoadBalancingV2::TargetGroup
release | CREATE_IN_PROGRESS ResourceDatabase AWS::CloudFormation::Stack
release | CREATE_IN_PROGRESS QueueBuilds AWS::SQS::Queue
release | CREATE_IN_PROGRESS ServiceWebListenerRule AWS::ElasticLoadBalancingV2::ListenerRule
release | CREATE_IN_PROGRESS QueueBuilds AWS::SQS::Queue
release | CREATE_IN_PROGRESS ServiceWebListenerRule AWS::ElasticLoadBalancingV2::ListenerRule
release | CREATE_IN_PROGRESS ServiceProxyListenerRule AWS::ElasticLoadBalancingV2::ListenerRule
release | CREATE_COMPLETE QueueBuilds AWS::SQS::Queue
release | CREATE_COMPLETE ServiceWebListenerRule AWS::ElasticLoadBalancingV2::ListenerRule
release | CREATE_COMPLETE ServiceProxyListenerRule AWS::ElasticLoadBalancingV2::ListenerRule
release | CREATE_COMPLETE KeyIntegrations AWS::KMS::Key
release | CREATE_COMPLETE KeyRacks AWS::KMS::Key
release | CREATE_IN_PROGRESS KeyIntegrationsAlias AWS::KMS::Alias
release | CREATE_IN_PROGRESS KeyRacksAlias AWS::KMS::Alias
release | CREATE_IN_PROGRESS KeyIntegrationsAlias AWS::KMS::Alias
release | CREATE_COMPLETE KeyIntegrationsAlias AWS::KMS::Alias
release | CREATE_IN_PROGRESS KeyRacksAlias AWS::KMS::Alias
release | CREATE_COMPLETE KeyRacksAlias AWS::KMS::Alias
stream error: stream ID 1; INTERNAL_ERROR
FAILURE: exit status 1
```