### PR TITLE
asg desired capacity has to be within range

### DIFF
--- a/provider/aws/formation/rack.json
+++ b/provider/aws/formation/rack.json
@@ -191,7 +191,7 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
         "Cooldown": "180",
-        "DesiredCapacity": "2",
+        "DesiredCapacity": { "Ref": "InstanceCountMin" },
         "HealthCheckType": "EC2",
         "HealthCheckGracePeriod": "120",
         "LaunchConfigurationName" : { "Ref": "InstancesConfig" },


### PR DESCRIPTION
This fixes a CF error if you try to increase InstanceCountMin:

```
07:56:10 UTC-0700	UPDATE_FAILED	AWS::AutoScaling::AutoScalingGroup	Instances	Desired capacity:2 must be between the specified min size:4 and max size:10
```