### PR TITLE
WIP: Integration Test Runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.env
+.env*
 .git
 cmd/cx/pkg
 examples

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.env
+.env*
 coverage.txt
 cmd/cx/pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 
 FROM convox/golang
 
-ENV DEVELOPMENT=true
-
 WORKDIR $GOPATH/src/github.com/convox/praxis
 
 COPY . .
@@ -11,8 +9,6 @@ COPY . .
 CMD ["rerun", "-watch", ".", "-build", "github.com/convox/praxis/cmd/rack"]
 
 ## convox:production
-
-ENV DEVELOPMENT=false
 
 WORKDIR $GOPATH/src/github.com/convox/praxis
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ WORKDIR $GOPATH/src/github.com/convox/praxis
 
 COPY . .
 
+RUN go install ./cmd/...
+
 CMD ["rerun", "-watch", ".", "-build", "github.com/convox/praxis/cmd/rack"]
 
 ## convox:production
 
 WORKDIR $GOPATH/src/github.com/convox/praxis
-
-RUN go install ./cmd/...
 
 CMD ["rack"]

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ coverage: ci
 dev: cli image
 	cx rack start
 
+integration:
+	bin/integration
+
 image:
 	docker build -t convox/praxis .
 
@@ -45,7 +48,9 @@ release:
 stats:
 	cloc . --exclude-dir=vendor
 
-test: check
+test: check unit integration
+
+unit:
 	env govendor test +local
 
 vendor:

--- a/Release.md
+++ b/Release.md
@@ -1,0 +1,71 @@
+Release Checklist
+    [ ] Local `cx test` passes against latest release:
+
+        $ cx update && cx rack update && cx version
+        client: 20170711112338
+        server: 20170711112338
+        
+        $ NAME=praxis-test cx test
+
+    [ ] AWS `cx test` passes against latest release:
+
+        1. Open PR on GitHub
+        2. Wait for workflow results
+        3. Retry workflow on transient errors
+
+        AWS `cx test` can also be run interactively:
+
+            $ cx switch convox/staging
+            $ cx test
+
+The release from the PR itself needs to preserve or fix tests. This can be verified with a local rack
+and praxis-local and praxis-aws apps with the new code:
+
+    [ ] Local `cx test` passes against PR
+
+        $ go build ./cmd/cx
+        $ ./cx apps create praxis-local
+        $ ./cx env set -a praxis-local DEVELOPMENT=true NAME=praxis-local PROVIDER=local PROVIDER_ROUTER=none VERSION=head
+        $ ./cx start -a praxis-local
+        $ export RACK_URL=https://rack.praxis-local.convox
+        $ ./cx version
+        client: dev
+        server: head
+
+        $ cx test
+
+    [ ] AWS `cx test` passes against PR
+
+        $ ./cx apps create praxis-aws
+        $ ./cx env set -a praxis-aws NAME=praxis-aws PROVIDER=aws VERSION=head
+        $ ./cx start -a praxis-local
+
+
+    Local `cx test` passes
+    AWS `cx test` passes
+
+    cx test works locally
+        on last release?
+            uninstall / install
+        on current release?
+            uninstall / install
+            `make something`
+                to replace latest cx and 
+
+
+
+
+Good release?
+    cx test works locally
+        problems
+            convergence bug
+            cmd/qa tests need to be deactivated
+
+    Workflows pass
+    Manual QA
+        rack install local
+            app deploy
+            app start
+        rack install aws
+            app deploy
+            traffic

--- a/bin/integration
+++ b/bin/integration
@@ -3,7 +3,7 @@
 set -ex
 export CONVOX_DEBUG=true
 
-go install ./cmd/cx
+env
 cx apps
 
 export RACK_URL=$(cx services -a $APP | grep "^rack" | cut -d" " -f3)

--- a/bin/integration
+++ b/bin/integration
@@ -7,7 +7,8 @@ env
 go install ./cmd/cx
 cx apps
 
-cx services
 export RACK_URL=$(cx services -a $APP | grep "^rack" | cut -d" " -f3)
 sleep 20
 cx apps
+
+govendor test ./cmd/qa -tags="qa"

--- a/bin/integration
+++ b/bin/integration
@@ -7,6 +7,7 @@ env
 go install ./cmd/cx
 cx apps
 
-export RACK_URL=$(cx services -a $APP | grep rack | cut -d" " -f3)
+cx services
+export RACK_URL=$(cx services -a $APP | grep "^rack" | cut -d" " -f3)
 sleep 20
 cx apps

--- a/bin/integration
+++ b/bin/integration
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+export CONVOX_DEBUG=true
+env
+
+go install ./cmd/cx
+cx apps
+
+export RACK_URL=$(cx services -a $APP | grep rack | cut -d" " -f3)
+sleep 20
+cx apps

--- a/bin/integration
+++ b/bin/integration
@@ -2,7 +2,6 @@
 
 set -ex
 export CONVOX_DEBUG=true
-env
 
 go install ./cmd/cx
 cx apps
@@ -11,4 +10,4 @@ export RACK_URL=$(cx services -a $APP | grep "^rack" | cut -d" " -f3)
 sleep 20
 cx apps
 
-govendor test ./cmd/qa -tags="qa"
+govendor test -tags="qa" -v ./cmd/qa

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -248,7 +248,14 @@ func build() error {
 }
 
 func release() error {
-	release, err := Rack.ReleaseCreate(flagApp, types.ReleaseCreateOptions{Build: flagId})
+	opts := types.ReleaseCreateOptions{Build: flagId}
+
+	env := types.Environment{
+		"DEVELOPMENT": fmt.Sprintf("%t", flagDevelopment),
+	}
+	opts.Env = env
+
+	release, err := Rack.ReleaseCreate(flagApp, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -176,7 +176,7 @@ func Rack(c *cli.Context) rack.Rack {
 		}
 
 		if proxy != nil {
-			rack, err := currentRack(c)
+			rack, err := rackFromContext(c)
 			if err != nil {
 				exit(err)
 			}
@@ -285,6 +285,19 @@ func consoleProxy() (*url.URL, error) {
 }
 
 func currentRack(c *cli.Context) (string, error) {
+	// RACK_URL always wins so use it if set
+	if os.Getenv("RACK_URL") != "" {
+		rack, err := Rack(c).SystemGet()
+		if err != nil {
+			return "", err
+		}
+		return rack.Name, nil
+	}
+
+	return rackFromContext(c)
+}
+
+func rackFromContext(c *cli.Context) (string, error) {
 	if c.GlobalString("rack") != "" {
 		return c.GlobalString("rack"), nil
 	}

--- a/cmd/cx/switch.go
+++ b/cmd/cx/switch.go
@@ -20,8 +20,8 @@ func runSwitch(c *cli.Context) error {
 		if err != nil {
 			return stdcli.Error(err)
 		}
-		sw := *stdcli.DefaultWriter
-		sw.Writef("%s\n", rack)
+
+		stdcli.Writef("%s\n", rack)
 		return nil
 	}
 

--- a/cmd/cx/test.go
+++ b/cmd/cx/test.go
@@ -44,6 +44,9 @@ func runTest(c *cli.Context) error {
 		return err
 	}
 
+	fmt.Printf("OS ENV: %+v\n", os.Environ())
+	fmt.Printf("M ENV: %+v\n", m.Environment)
+
 	system := m.Writer("convox", os.Stdout)
 
 	stdcli.DefaultWriter.Stdout = system

--- a/cmd/cx/test.go
+++ b/cmd/cx/test.go
@@ -57,17 +57,16 @@ func runTest(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer Rack(c).AppDelete(name)
+
+	if err := tickWithTimeout(2*time.Second, 1*time.Minute, notAppStatus(Rack(c), name, "creating")); err != nil {
+		return err
+	}
 
 	_, err = Rack(c).ReleaseCreate(name, types.ReleaseCreateOptions{
 		Env: m.Environment,
 	})
 	if err != nil {
-		return err
-	}
-
-	defer Rack(c).AppDelete(name)
-
-	if err := tickWithTimeout(2*time.Second, 1*time.Minute, notAppStatus(Rack(c), name, "creating")); err != nil {
 		return err
 	}
 

--- a/cmd/qa/app_test.go
+++ b/cmd/qa/app_test.go
@@ -1,0 +1,209 @@
+// +build qa
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/convox/praxis/sdk/rack"
+	"github.com/convox/praxis/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppCreate(t *testing.T) {
+	Rack, err := rack.NewFromEnv()
+	assert.NoError(t, err)
+
+	app, err := Rack.AppCreate("")
+	assert.EqualError(t, err, "app name required")
+	assert.Nil(t, app)
+
+	app, err = Rack.AppCreate("3")
+	assert.EqualError(t, err, "app name invalid")
+	assert.Nil(t, app)
+
+	app, err = appCreate(Rack, "valid")
+	assert.NoError(t, err)
+	defer appDelete(Rack, "valid")
+
+	assert.EqualValues(t, &types.App{
+		Name:    "valid",
+		Release: "",
+		Status:  "running",
+	}, app)
+
+	app, err = Rack.AppCreate("valid")
+	assert.EqualError(t, err, "app already exists: valid")
+	assert.Nil(t, app)
+}
+
+func TestAppDelete(t *testing.T) {
+	Rack, err := rack.NewFromEnv()
+	assert.NoError(t, err)
+
+	err = Rack.AppDelete("")
+	assert.EqualError(t, err, "response status 404")
+
+	err = Rack.AppDelete("3")
+	assert.EqualError(t, err, "app name invalid")
+
+	err = Rack.AppDelete("missing")
+	assert.EqualError(t, err, "no such app: missing")
+
+	app, err := appCreate(Rack, "valid")
+	assert.NoError(t, err)
+	err = appDelete(Rack, app.Name)
+	assert.EqualError(t, err, "no such app: valid")
+}
+
+func TestAppGet(t *testing.T) {
+	Rack, err := rack.NewFromEnv()
+	assert.NoError(t, err)
+
+	app, err := Rack.AppGet("")
+	assert.EqualError(t, err, "response status 404")
+	assert.Nil(t, app)
+
+	app, err = Rack.AppGet("3")
+	assert.EqualError(t, err, "app name invalid")
+	assert.Nil(t, app)
+
+	app, err = appCreate(Rack, "valid")
+	assert.NoError(t, err)
+	defer appDelete(Rack, "valid")
+
+	a, err := Rack.AppGet("valid")
+	assert.NoError(t, err)
+	assert.EqualValues(t, app, a)
+}
+
+func TestAppList(t *testing.T) {
+	Rack, err := rack.NewFromEnv()
+	assert.NoError(t, err)
+
+	apps, err := Rack.AppList()
+	assert.NoError(t, err)
+	assert.EqualValues(t, types.Apps{}, apps)
+
+	_, err = appCreate(Rack, "foo")
+	assert.NoError(t, err)
+	defer appDelete(Rack, "foo")
+
+	_, err = appCreate(Rack, "bar")
+	assert.NoError(t, err)
+	defer appDelete(Rack, "bar")
+
+	apps, err = Rack.AppList()
+	assert.NoError(t, err)
+	assert.EqualValues(t, types.Apps{
+		types.App{
+			Name:    "bar",
+			Release: "",
+			Status:  "running",
+		},
+		types.App{
+			Name:    "foo",
+			Release: "",
+			Status:  "running",
+		},
+	}, apps)
+}
+func TestAppLogs(t *testing.T) {
+	Rack, err := rack.NewFromEnv()
+	assert.NoError(t, err)
+
+	app, err := appCreate(Rack, "valid")
+	assert.NoError(t, err)
+	defer appDelete(Rack, "valid")
+
+	r, err := Rack.AppLogs(app.Name, types.LogsOptions{})
+	assert.NoError(t, err)
+	b, err := ioutil.ReadAll(r)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{}, b)
+
+	// FIXME: assert app process logs
+	// FIXME: assert log options filter, follow, prefix, since
+}
+
+func TestAppRegistry(t *testing.T) {
+	Rack, err := rack.NewFromEnv()
+	assert.NoError(t, err)
+
+	app, err := appCreate(Rack, "valid")
+	defer appDelete(Rack, app.Name)
+
+	r, err := Rack.AppRegistry(app.Name)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, r.Hostname)
+}
+
+func appCreate(r rack.Rack, name string) (*types.App, error) {
+	a, err := r.AppCreate(name)
+	if err != nil {
+		return a, err
+	}
+
+	if err := tickWithTimeout(2*time.Second, 2*time.Minute, notAppStatus(r, name, "creating")); err != nil {
+		return nil, err
+	}
+
+	return r.AppGet(name)
+}
+
+func appDelete(r rack.Rack, name string) error {
+	err := r.AppDelete(name)
+	if err != nil {
+		return err
+	}
+
+	if err := tickWithTimeout(2*time.Second, 2*time.Minute, notAppStatus(r, name, "running")); err != nil {
+		return err
+	}
+
+	if err := tickWithTimeout(2*time.Second, 2*time.Minute, notAppStatus(r, name, "deleting")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func notAppStatus(r rack.Rack, app, status string) func() (bool, error) {
+	return func() (bool, error) {
+		app, err := r.AppGet(app)
+		if err != nil {
+			return true, err
+		}
+
+		if app.Status != status {
+			return true, nil
+		}
+
+		return false, nil
+	}
+}
+
+func tickWithTimeout(tick time.Duration, timeout time.Duration, fn func() (stop bool, err error)) error {
+	tickch := time.Tick(tick)
+	timeoutch := time.After(timeout)
+
+	for {
+		stop, err := fn()
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+
+		select {
+		case <-tickch:
+			continue
+		case <-timeoutch:
+			return fmt.Errorf("timeout")
+		}
+	}
+}

--- a/cmd/qa/app_test.go
+++ b/cmd/qa/app_test.go
@@ -25,18 +25,19 @@ func TestAppCreate(t *testing.T) {
 	assert.EqualError(t, err, "app name invalid")
 	assert.Nil(t, app)
 
-	app, err = appCreate(Rack, "valid")
+	name := fmt.Sprintf("test-%d", time.Now().Unix())
+	app, err = appCreate(Rack, name)
 	assert.NoError(t, err)
-	defer appDelete(Rack, "valid")
+	defer appDelete(Rack, name)
 
 	assert.EqualValues(t, &types.App{
-		Name:    "valid",
+		Name:    name,
 		Release: "",
 		Status:  "running",
 	}, app)
 
-	app, err = Rack.AppCreate("valid")
-	assert.EqualError(t, err, "app already exists: valid")
+	app, err = Rack.AppCreate(name)
+	assert.EqualError(t, err, fmt.Sprintf("app already exists: %s", name))
 	assert.Nil(t, app)
 }
 
@@ -53,10 +54,11 @@ func TestAppDelete(t *testing.T) {
 	err = Rack.AppDelete("missing")
 	assert.EqualError(t, err, "no such app: missing")
 
-	app, err := appCreate(Rack, "valid")
+	name := fmt.Sprintf("test-%d", time.Now().Unix())
+	_, err = appCreate(Rack, name)
 	assert.NoError(t, err)
-	err = appDelete(Rack, app.Name)
-	assert.EqualError(t, err, "no such app: valid")
+	err = appDelete(Rack, name)
+	assert.EqualError(t, err, fmt.Sprintf("no such app: %s", name))
 }
 
 func TestAppGet(t *testing.T) {
@@ -71,11 +73,12 @@ func TestAppGet(t *testing.T) {
 	assert.EqualError(t, err, "app name invalid")
 	assert.Nil(t, app)
 
-	app, err = appCreate(Rack, "valid")
+	name := fmt.Sprintf("test-%d", time.Now().Unix())
+	app, err = appCreate(Rack, name)
 	assert.NoError(t, err)
-	defer appDelete(Rack, "valid")
+	defer appDelete(Rack, name)
 
-	a, err := Rack.AppGet("valid")
+	a, err := Rack.AppGet(name)
 	assert.NoError(t, err)
 	assert.EqualValues(t, app, a)
 }
@@ -88,24 +91,26 @@ func TestAppList(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, types.Apps{}, apps)
 
-	_, err = appCreate(Rack, "foo")
+	name1 := fmt.Sprintf("foo-%d", time.Now().Unix())
+	_, err = appCreate(Rack, name1)
 	assert.NoError(t, err)
-	defer appDelete(Rack, "foo")
+	defer appDelete(Rack, name1)
 
-	_, err = appCreate(Rack, "bar")
+	name2 := fmt.Sprintf("bar-%d", time.Now().Unix())
+	_, err = appCreate(Rack, name2)
 	assert.NoError(t, err)
-	defer appDelete(Rack, "bar")
+	defer appDelete(Rack, name2)
 
 	apps, err = Rack.AppList()
 	assert.NoError(t, err)
 	assert.EqualValues(t, types.Apps{
 		types.App{
-			Name:    "bar",
+			Name:    name2,
 			Release: "",
 			Status:  "running",
 		},
 		types.App{
-			Name:    "foo",
+			Name:    name1,
 			Release: "",
 			Status:  "running",
 		},
@@ -115,11 +120,12 @@ func TestAppLogs(t *testing.T) {
 	Rack, err := rack.NewFromEnv()
 	assert.NoError(t, err)
 
-	app, err := appCreate(Rack, "valid")
+	name := fmt.Sprintf("test-%d", time.Now().Unix())
+	_, err = appCreate(Rack, name)
 	assert.NoError(t, err)
-	defer appDelete(Rack, "valid")
+	defer appDelete(Rack, name)
 
-	r, err := Rack.AppLogs(app.Name, types.LogsOptions{})
+	r, err := Rack.AppLogs(name, types.LogsOptions{})
 	assert.NoError(t, err)
 	b, err := ioutil.ReadAll(r)
 	assert.NoError(t, err)
@@ -133,10 +139,11 @@ func TestAppRegistry(t *testing.T) {
 	Rack, err := rack.NewFromEnv()
 	assert.NoError(t, err)
 
-	app, err := appCreate(Rack, "valid")
-	defer appDelete(Rack, app.Name)
+	name := fmt.Sprintf("test-%d", time.Now().Unix())
+	_, err = appCreate(Rack, name)
+	defer appDelete(Rack, name)
 
-	r, err := Rack.AppRegistry(app.Name)
+	r, err := Rack.AppRegistry(name)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, r.Hostname)
 }

--- a/cmd/qa/main.go
+++ b/cmd/qa/main.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {
+}

--- a/convox.yml
+++ b/convox.yml
@@ -5,6 +5,7 @@ services:
       - AWS_REGION=
       - AWS_ACCESS_KEY_ID=
       - AWS_SECRET_ACCESS_KEY=
+      - DEVELOPMENT=false
       - NAME=convox
       - PASSWORD=
       - PROVIDER=

--- a/convox.yml
+++ b/convox.yml
@@ -9,6 +9,7 @@ services:
       - NAME=convox
       - PASSWORD=
       - PROVIDER=
+      - PROVIDER_ROUTER=
       - TEST=false
       - VERSION=
     port: https:3000

--- a/helpers/validate.go
+++ b/helpers/validate.go
@@ -1,0 +1,20 @@
+package helpers
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// ValidateAppName asserts an alphanumeric app name is provided
+func ValidateAppName(name string) error {
+	if name == "" {
+		return fmt.Errorf("app name required")
+	}
+
+	r := regexp.MustCompile("^([a-z][a-z0-9-]+)$")
+	if !r.Match([]byte(name)) {
+		return fmt.Errorf("app name invalid")
+	}
+
+	return nil
+}

--- a/parallel.sh
+++ b/parallel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+script -q /dev/null cx run -a httpd --rack noah/dev2 web ping -c20 google.com &
+script -q /dev/null cx run -a httpd --rack noah/dev2 web ping -c20 google.com &
+script -q /dev/null cx run -a httpd --rack noah/dev2 web ping -c20 google.com &
+script -q /dev/null cx run -a httpd --rack noah/dev2 web ping -c20 google.com &
+script -q /dev/null cx run -a httpd --rack noah/dev2 web ping -c20 google.com &
+
+wait

--- a/provider/aws/app.go
+++ b/provider/aws/app.go
@@ -49,14 +49,15 @@ func (p *Provider) AppCreate(name string) (*types.App, error) {
 }
 
 func (p *Provider) AppDelete(name string) error {
-	if err := helpers.ValidateAppName(name); err != nil {
+	app, err := p.AppGet(name)
+	if err != nil {
 		return err
 	}
 
-	bucket, _ := p.appResource(name, "Bucket")
+	bucket, _ := p.appResource(app.Name, "Bucket")
 
-	_, err := p.CloudFormation().DeleteStack(&cloudformation.DeleteStackInput{
-		StackName: aws.String(fmt.Sprintf("%s-%s", p.Name, name)),
+	_, err = p.CloudFormation().DeleteStack(&cloudformation.DeleteStackInput{
+		StackName: aws.String(fmt.Sprintf("%s-%s", p.Name, app.Name)),
 	})
 	if err != nil {
 		return err

--- a/provider/aws/app.go
+++ b/provider/aws/app.go
@@ -9,10 +9,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/convox/praxis/helpers"
 	"github.com/convox/praxis/types"
 )
 
 func (p *Provider) AppCreate(name string) (*types.App, error) {
+	if err := helpers.ValidateAppName(name); err != nil {
+		return nil, err
+	}
+
 	data, err := formationTemplate("app", nil)
 	if err != nil {
 		return nil, err
@@ -44,6 +49,10 @@ func (p *Provider) AppCreate(name string) (*types.App, error) {
 }
 
 func (p *Provider) AppDelete(name string) error {
+	if err := helpers.ValidateAppName(name); err != nil {
+		return err
+	}
+
 	bucket, _ := p.appResource(name, "Bucket")
 
 	_, err := p.CloudFormation().DeleteStack(&cloudformation.DeleteStackInput{
@@ -63,6 +72,10 @@ func (p *Provider) AppDelete(name string) error {
 }
 
 func (p *Provider) AppGet(name string) (*types.App, error) {
+	if err := helpers.ValidateAppName(name); err != nil {
+		return nil, err
+	}
+
 	stack, err := p.describeStack(fmt.Sprintf("%s-%s", p.Name, name))
 	if awsError(err) == "ValidationError" {
 		return nil, fmt.Errorf("no such app: %s", name)

--- a/provider/aws/build.go
+++ b/provider/aws/build.go
@@ -49,9 +49,10 @@ func (p *Provider) BuildCreate(app, url string, opts types.BuildCreateOptions) (
 	pid, err := p.ProcessStart(app, types.ProcessRunOptions{
 		Command: fmt.Sprintf("build -id %s -url %s", id, url),
 		Environment: map[string]string{
-			"BUILD_APP":    app,
-			"BUILD_PREFIX": fmt.Sprintf("%s-%s", p.Name, app),
-			"BUILD_PUSH":   fmt.Sprintf("%s/%s", ar.Hostname, repo),
+			"BUILD_APP":         app,
+			"BUILD_DEVELOPMENT": fmt.Sprintf("%t", opts.Development),
+			"BUILD_PREFIX":      fmt.Sprintf("%s-%s", p.Name, app),
+			"BUILD_PUSH":        fmt.Sprintf("%s/%s", ar.Hostname, repo),
 		},
 		Name:    fmt.Sprintf("%s-%s-build-%s", p.Name, app, id),
 		Image:   sys.Image,

--- a/provider/aws/process.go
+++ b/provider/aws/process.go
@@ -113,7 +113,7 @@ func (p *Provider) ProcessGet(app, pid string) (*types.Process, error) {
 	}
 
 	if ps.App != app {
-		return nil, fmt.Errorf("process not found: %s\n", pid)
+		return nil, fmt.Errorf("process not found: %s", pid)
 	}
 
 	return ps, nil
@@ -214,12 +214,28 @@ func (p *Provider) ProcessRun(app string, opts types.ProcessRunOptions) (int, er
 			return 0, err
 		}
 
-		return p.ProcessExec(app, pid, opts.Command, types.ProcessExecOptions{
+		code, err := p.ProcessExec(app, pid, opts.Command, types.ProcessExecOptions{
 			Height: opts.Height,
 			Width:  opts.Width,
 			Input:  opts.Input,
 			Output: opts.Output,
 		})
+
+		// terminate parent to free up task reservation
+		serr := p.ProcessStop(app, pid)
+
+		// report exec error
+		if err != nil {
+			return code, err
+		}
+
+		// report terminate error
+		if serr != nil {
+			return code, serr
+		}
+
+		// success
+		return code, nil
 	}
 
 	if err := p.ECS().WaitUntilTasksStopped(treq); err != nil {

--- a/provider/aws/process.go
+++ b/provider/aws/process.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/convox/praxis/cache"
 	"github.com/convox/praxis/types"
 	docker "github.com/fsouza/go-dockerclient"
 	shellquote "github.com/kballard/go-shellquote"
@@ -240,6 +241,12 @@ func (p *Provider) ProcessRun(app string, opts types.ProcessRunOptions) (int, er
 }
 
 func (p *Provider) ProcessStart(app string, opts types.ProcessRunOptions) (string, error) {
+	// clear the AppGet cache to avoid "no releases for app"
+	err := cache.Clear("describeStack", fmt.Sprintf("%s-%s", p.Name, app))
+	if err != nil {
+		return "", err
+	}
+
 	cluster, err := p.rackResource("RackCluster")
 	if err != nil {
 		return "", err

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/simpledb"
+	"github.com/convox/praxis/cache"
 	"github.com/convox/praxis/helpers"
 	"github.com/convox/praxis/types"
 )
@@ -137,6 +138,12 @@ func (p *Provider) ReleaseLogs(app, id string, opts types.LogsOptions) (io.ReadC
 }
 
 func (p *Provider) ReleasePromote(app string, id string) error {
+	// clear the AppGet cache to avoid "response status 404"
+	err := cache.Clear("describeStack", fmt.Sprintf("%s-%s", p.Name, app))
+	if err != nil {
+		return err
+	}
+
 	a, err := p.AppGet(app)
 	if err != nil {
 		return err

--- a/provider/aws/service.go
+++ b/provider/aws/service.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 
+	"github.com/convox/praxis/cache"
 	"github.com/convox/praxis/helpers"
 	"github.com/convox/praxis/types"
 )
@@ -23,6 +24,12 @@ func (p *Provider) ServiceGet(app, name string) (*types.Service, error) {
 }
 
 func (p *Provider) ServiceList(app string) (types.Services, error) {
+	// clear the AppGet cache to avoid "no releases for app"
+	err := cache.Clear("describeStack", fmt.Sprintf("%s-%s", p.Name, app))
+	if err != nil {
+		return nil, err
+	}
+
 	m, _, err := helpers.AppManifest(p, app)
 	if err != nil {
 		return nil, err

--- a/provider/local/build.go
+++ b/provider/local/build.go
@@ -59,8 +59,6 @@ func (p *Provider) BuildCreate(app, url string, opts types.BuildCreateOptions) (
 	buildUpdateLock.Lock()
 	defer buildUpdateLock.Unlock()
 
-	fmt.Printf("opts = %+v\n", opts)
-
 	pid, err := p.ProcessStart(app, types.ProcessRunOptions{
 		Command: fmt.Sprintf("build -id %s -url %s", id, url),
 		Environment: map[string]string{

--- a/provider/local/converge.go
+++ b/provider/local/converge.go
@@ -101,24 +101,27 @@ func (p *Provider) converge(app string) error {
 	}
 
 	// TODO: remove
-	dt := http.DefaultTransport.(*http.Transport)
-	dt.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true,
+	fmt.Printf("ROUTER: %+v\n", p.Router)
+	if p.Router != "none" {
+		dt := http.DefaultTransport.(*http.Transport)
+		dt.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+
+		hc := http.Client{Transport: dt}
+
+		req, err := http.NewRequest("POST", fmt.Sprintf("https://%s/version/%s", p.Router, p.Version), nil)
+		if err != nil {
+			return err
+		}
+
+		res, err := hc.Do(req)
+		if err != nil {
+			return err
+		}
+
+		defer res.Body.Close()
 	}
-
-	hc := http.Client{Transport: dt}
-
-	req, err := http.NewRequest("POST", fmt.Sprintf("https://%s/version/%s", p.Router, p.Version), nil)
-	if err != nil {
-		return err
-	}
-
-	res, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer res.Body.Close()
 
 	return log.Success()
 }

--- a/provider/local/helpers.go
+++ b/provider/local/helpers.go
@@ -1,6 +1,9 @@
 package local
 
+import "fmt"
+
 func coalesce(strings ...string) string {
+	fmt.Printf("COALESCE: %+v\n", strings)
 	for _, s := range strings {
 		if s != "" {
 			return s

--- a/provider/local/local.go
+++ b/provider/local/local.go
@@ -48,6 +48,8 @@ func FromEnv() (*Provider, error) {
 		Version: "latest",
 	}
 
+	fmt.Printf("Provider FromEnv: %+v\n", p)
+
 	if v := os.Getenv("VERSION"); v != "" {
 		p.Version = v
 	}

--- a/provider/local/process.go
+++ b/provider/local/process.go
@@ -187,7 +187,7 @@ func (p *Provider) ProcessRun(app string, opts types.ProcessRunOptions) (int, er
 	log := p.logger("ProcessRun").Append("app=%q", app)
 
 	if opts.Name != "" {
-		exec.Command("docker", "rm", "-f", opts.Name).Run()
+		exec.Command("docker", "-f", opts.Name).Run()
 	}
 
 	oargs, err := p.argsFromOpts(app, opts)
@@ -406,6 +406,7 @@ func (p *Provider) argsFromOpts(app string, opts types.ProcessRunOptions) ([]str
 		args = append(args, "sh", "-c", opts.Command)
 	}
 
+	fmt.Printf("args: %v\n", args)
 	return args, nil
 }
 

--- a/provider/local/process.go
+++ b/provider/local/process.go
@@ -355,9 +355,9 @@ func (p *Provider) argsFromOpts(app string, opts types.ProcessRunOptions) ([]str
 
 	// FIXME try letting docker daemon pass through dns
 	// if this works long term can delete this
-	// if p.Router != "" {
-	//   args = append(args, "--dns", p.Router)
-	// }
+	if p.Router != "" {
+		args = append(args, "--dns", p.Router)
+	}
 
 	for k, v := range opts.Environment {
 		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))

--- a/provider/local/release.go
+++ b/provider/local/release.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/convox/praxis/types"
@@ -53,6 +54,9 @@ func (p *Provider) ReleaseGet(app, id string) (*types.Release, error) {
 	var r *types.Release
 
 	if err := p.storageLoad(fmt.Sprintf("apps/%s/releases/%s/release.json", app, id), &r, ReleaseCacheDuration); err != nil {
+		if strings.Contains(err.Error(), "no such key") {
+			return nil, fmt.Errorf("release not found")
+		}
 		return nil, errors.WithStack(log.Error(err))
 	}
 	if r == nil {


### PR DESCRIPTION
# Release Checklist

The `cx test` command should consistently pass against the currently released version.

- [x] Local `cx test` passes against latest release

        $ cx update && cx rack update && cx version
        client: 20170711112338
        server: 20170711112338
        
        $ NAME=praxis-test cx test

- [ ] AWS `cx test` passes against latest release
  - [ ] Open PR on GitHub
  - [ ] Wait for workflow results
  - [ ] Retry workflow on transient errors
  - [ ] AWS `cx test` can also be run interactively:

        $ cx switch convox/staging
        $ cx test

The `cx test` command should also pass against the new version that will be the result of this PR. This can be verified on a local rack with `praxis-local` and `praxis-aws` apps running this code

- [ ] `cx test` passes against dev local provider

        $ go build ./cmd/cx
        $ ./cx apps create praxis-local
        $ ./cx env set -a praxis-local DEVELOPMENT=true NAME=praxis-local PROVIDER=local PROVIDER_ROUTER=none VERSION=head
        $ ./cx start -a praxis-local
        $ export RACK_URL=https://rack.praxis-local.convox
        $ ./cx version
        client: dev
        server: head

        $ cx test

- [ ] `cx test` passes against dev AWS provider

        $ ./cx apps create praxis-aws
        $ ./cx env set -a praxis-aws AWS_REGION= AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= NAME=praxis-aws PROVIDER=aws VERSION=head
        $ ./cx start -a praxis-aws
        $ ./cx version
        client: dev
        server: head

        $ cx test

Once tests pass:

- [ ] Make release
- [ ] Update staging rack
- [ ] Deploy ui with new client version
- [ ] Retry workflow
- [ ] Update production rack
