### PR TITLE
env var for cx test

### DIFF
--- a/cmd/cx/test.go
+++ b/cmd/cx/test.go
@@ -22,7 +22,9 @@ func init() {
 }
 
 func runTest(c *cli.Context) error {
-	env := manifest.Environment{}
+	env := manifest.Environment{
+		"TEST": "true",
+	}
 
 	for _, e := range os.Environ() {
 		parts := strings.SplitN(e, "=", 2)

--- a/convox.yml
+++ b/convox.yml
@@ -8,6 +8,7 @@ services:
       - NAME=convox
       - PASSWORD=
       - PROVIDER=
+      - TEST=false
       - VERSION=
     port: https:3000
     scale:

--- a/provider/local/local.go
+++ b/provider/local/local.go
@@ -44,6 +44,7 @@ func FromEnv() (*Provider, error) {
 		Name:    coalesce(os.Getenv("NAME"), "convox"),
 		Root:    coalesce(os.Getenv("PROVIDER_ROOT"), "/var/convox"),
 		Router:  coalesce(os.Getenv("PROVIDER_ROUTER"), "10.42.0.0"),
+		Test:    os.Getenv("TEST") == "true",
 		Version: "latest",
 	}
 

--- a/provider/local/workers.go
+++ b/provider/local/workers.go
@@ -22,15 +22,17 @@ func (p *Provider) Workers() {
 		}
 	}()
 
-	go func() {
-		for {
-			time.Sleep(10 * time.Second)
+	if !p.Test {
+		go func() {
+			for {
+				time.Sleep(10 * time.Second)
 
-			if err := p.workerConverge(); err != nil {
-				log.Error(errors.WithStack(err))
+				if err := p.workerConverge(); err != nil {
+					log.Error(errors.WithStack(err))
+				}
 			}
-		}
-	}()
+		}()
+	}
 }
 
 func (p *Provider) workerConverge() error {


### PR DESCRIPTION
Addresses the `exit 137` error seen when running `cx test`. 

When running `cx test` against praxis, the local rack and the test app would have the same name. This would cause the test app to stop itself during converge as it saw running processes with it's rack name that didn't exist from it's point of view. 

Hopefully thats explained clearly.