### PR TITLE
correct --build-arg flag

### DIFF
--- a/manifest/build.go
+++ b/manifest/build.go
@@ -395,7 +395,7 @@ func buildArgs(dockerfile string, opts BuildOptions) ([]string, error) {
 		case "ARG":
 			k := strings.TrimSpace(parts[0])
 			if v, ok := opts.Env[k]; ok {
-				args = append(args, "--build-args", fmt.Sprintf("%s=%s", k, v))
+				args = append(args, "--build-arg", fmt.Sprintf("%s=%s", k, v))
 			}
 		}
 	}


### PR DESCRIPTION
Builds that use ARG are failing

```
$ cx deploy
building: /Users/noah/dev/myapp
uploading: OK
starting build: c02779d2-fc47-413f-a630-85a3f00d1506
preparing source
building: .
running: docker build -t 9836064b94124bad54f83c70026dd85fcb8b5a13 --build-args RAILS_ENV=production --build-args SECRET_TOKEN=foo
unknown flag: --build-args
See 'docker build --help'.
build error: exit status 125
build failed
```