### PR TITLE
Fix Sync add error

### DIFF
--- a/cmd/cx/start.go
+++ b/cmd/cx/start.go
@@ -312,7 +312,7 @@ func handleAdds(r rack.Rack, app, pid, remote string, adds []changes.Change) err
 		stat, err := os.Stat(local)
 		if err != nil {
 			// skip transient files like '.git/.COMMIT_EDITMSG.swp'
-			if strings.Contains(err.Error(), "no such file or directory") {
+			if os.IsNotExist(err) {
 				continue
 			}
 

--- a/cmd/cx/start.go
+++ b/cmd/cx/start.go
@@ -311,6 +311,11 @@ func handleAdds(r rack.Rack, app, pid, remote string, adds []changes.Change) err
 
 		stat, err := os.Stat(local)
 		if err != nil {
+			// skip transient files like '.git/.COMMIT_EDITMSG.swp'
+			if strings.Contains(err.Error(), "no such file or directory") {
+				continue
+			}
+
 			return err
 		}
 


### PR DESCRIPTION
I can reproducibly cause `cx start` sync to freeze by opening up a vim session in an app directory

```
$ git clone https://github.com/convox/docs.git && cx docs
$ cx start

# open up vim for a commit message, and quickly :wq
$ git commit --amend
```

It displays this error and no longer syncs or responds to CTRL-C:

```
convox  | sync: 6 files to web
convox  | sync add error: stat /Users/noah/dev/docs/.git/.COMMIT_EDITMSG.swp: no such file or directory
```

This patch fixes it, however I suspect it doesn't totally address the deadlock problem.