### PR TITLE
Correct version on install; friendly server error

### DIFF
--- a/cmd/cx/version.go
+++ b/cmd/cx/version.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"runtime"
+	"strings"
 
 	"github.com/convox/praxis/stdcli"
 	cli "gopkg.in/urfave/cli.v1"
@@ -24,7 +26,10 @@ func runVersion(c *cli.Context) error {
 
 	rack, err := Rack(c).SystemGet()
 	if err != nil {
-		fmt.Printf("server: error\n")
+		if os.Getenv("RACK_URL") == "https://localhost:5443" && strings.Contains(err.Error(), "connection refused") {
+			fmt.Printf("server: error\n")
+			return fmt.Errorf("Could not connect to local Rack. Is it installed and Docker running?")
+		}
 		return err
 	}
 

--- a/cmd/cx/version.go
+++ b/cmd/cx/version.go
@@ -24,7 +24,7 @@ func runVersion(c *cli.Context) error {
 
 	rack, err := Rack(c).SystemGet()
 	if err != nil {
-		fmt.Printf("server: error: %s\n", err)
+		fmt.Printf("server: error\n")
 		return err
 	}
 

--- a/provider/local/system.go
+++ b/provider/local/system.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"runtime"
 	"text/template"
 	"time"
 
@@ -51,6 +52,17 @@ func (p *Provider) SystemInstall(name string, opts types.SystemInstallOptions) (
 
 	if opts.Output != nil {
 		fmt.Fprintf(opts.Output, "pulling: convox/praxis:%s\n", opts.Version)
+	}
+
+	vf := "/var/convox/version"
+
+	switch runtime.GOOS {
+	case "darwin":
+		vf = "/Users/Shared/convox/version"
+	}
+
+	if err := ioutil.WriteFile(vf, []byte(opts.Version), 0644); err != nil {
+		return "", err
 	}
 
 	cmd := exec.Command("docker", "pull", fmt.Sprintf("convox/praxis:%s", opts.Version))


### PR DESCRIPTION
Now:

```
$ ./cx version
client: dev
server: 20170725144836

$ ./cx rack update --channel edge
updating convox to 20170727110712: OK

$ sudo ./cx rack uninstall local
removing: /Library/LaunchDaemons/convox.frontend.plist
removing: /Library/LaunchDaemons/convox.rack.plist
removing: /Library/LaunchDaemons/convox.router.plist

$ ./cx version
client: dev
server: error
Could not connect to local Rack. Is it installed and Docker running?

$ sudo ./cx rack install local
pulling: convox/praxis:20170725144836
installing: /Library/LaunchDaemons/convox.router.plist
installing: /Library/LaunchDaemons/convox.rack.plist

$ ./cx version
client: dev
server: 20170725144836
```

Before:

```
$ cx version
client: 20170727110712
server: error: Get https://localhost:5443/system?: dial tcp [::1]:5443: getsockopt: connection refused
Get https://localhost:5443/system?: dial tcp [::1]:5443: getsockopt: connection refused
```